### PR TITLE
Add cron folder and readme about its use

### DIFF
--- a/cron.d/README
+++ b/cron.d/README
@@ -1,0 +1,3 @@
+#Files placed here will be automatically copied to /etc/cron.d/ on the the alma-sftp instance.  
+#Care should be taken to only place files formatted as a cron job here, for example - 
+#11 19 * * *   root    echo "hello world"


### PR DESCRIPTION
This folder and file are necessary for the logic of the deployment of the Ec2 instance to finish successfully.