### PR TITLE
Go live changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# About this project
+This repository contains scripts related to the Alma migration, and is primarily used in the alma-sftp-ec2 instance.  
+
+# Directories 
+## Cron.d 
+This directory contains cron jobs, added to the cron.d directory on alma-sftp-ec2 automatically.  
+
+## scripts
+This directory contains the scripts that need to run on alma-sftp-ec2.
+

--- a/cron.d/alma-exports
+++ b/cron.d/alma-exports
@@ -1,4 +1,6 @@
 # Cron jobs for alma exports
-# Possible future cron jobs 
-3 3 * * * root /mnt/alma/alma-scripts/scripts/Update-Export.sh 
+# At 0803
+3 8 * * * root /mnt/alma/alma-scripts/scripts/Update-Export.sh 
+
+# At 0030 on the 2nd of the month
 30 0 2 * * root /mnt/alma/alma-scripts/scripts/Full-Export.sh

--- a/cron.d/alma-exports
+++ b/cron.d/alma-exports
@@ -1,4 +1,4 @@
 # Cron jobs for alma exports
 # Possible future cron jobs 
-# 3 0 * * * root /mnt/alma/alma-scripts/scripts/Update-Export.sh 
-# 30 0 2 * * root /mnt/alma/alma-scripts/scripts/Full-Export.sh
+3 3 * * * root /mnt/alma/alma-scripts/scripts/Update-Export.sh 
+30 0 2 * * root /mnt/alma/alma-scripts/scripts/Full-Export.sh

--- a/scripts/Full-Export.sh
+++ b/scripts/Full-Export.sh
@@ -6,10 +6,8 @@ now=$(date +"%Y-%m-%d")
 mkdir /mnt/alma/FullUpdate_automated
 cd /mnt/alma/FullUpdate_automated
 
-# Copy down all the MRC files (tar files?)
+# Copy down all the MRC files 
 aws s3 sync s3://$ALMA_BUCKET/exlibris/Timdex/FULL/ . --delete --exclude "*" --include "*.mrc"
-
-## todo: fix untar (not sure if single or multiple files)
 
 # Remove the previous run's tmp file
 rm result.tmp
@@ -25,7 +23,6 @@ aws s3 cp result.tmp s3://$DIP_ALEPH_BUCKET/ALMA_FULL_EXPORT_$now.mrc
 
 ## todo: Find whether lambda ran successfully or decide success of above docker run
 
-## todo: move files to archive location for them to be deleted as they age out?
+aws s3 mv s3://$ALMA_BUCKET/exlibris/Timdex/FULL/ s3://$ALMA_BUCKET/exlibris/Timdex/FULL/ARCHIVE/ --exclude "*" --include "*.mrc" --recursive
 
-#rm *.mrc
-#aws s3 rm s3://$ALMA_BUCKET/exlibris/Timdex/FULL/
+rm *.mrc

--- a/scripts/Update-Export.sh
+++ b/scripts/Update-Export.sh
@@ -14,7 +14,7 @@ aws s3 sync s3://$ALMA_BUCKET/exlibris/Timdex/UPDATE/ . --delete --exclude "*" -
 rm result.tmp
 
 # Concat all the mrc files into one file
-cat *.mrc >> result.tmp
+cat `ls|grep ".mrc"|sort -n` >> result.tmp 
 
 # Upload the file to s3, name it properly
 aws s3 cp result.tmp s3://$DIP_ALEPH_BUCKET/ALMA_UPDATE_EXPORT_$now.mrc
@@ -24,5 +24,6 @@ aws s3 cp result.tmp s3://$DIP_ALEPH_BUCKET/ALMA_UPDATE_EXPORT_$now.mrc
 
 aws s3 mv s3://$ALMA_BUCKET/exlibris/Timdex/UPDATE/ s3://$ALMA_BUCKET/exlibris/Timdex/UPDATE/ARCHIVE/ --exclude "*" --include "*.mrc" --recursive
 
+#Clean up
 rm *.mrc
-
+rm *.tmp

--- a/scripts/Update-Export.sh
+++ b/scripts/Update-Export.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# ###########################
-# This is currently untested, and should not be used...
-# ###########################
-
 # Create date string
 now=$(date +"%Y-%m-%d")
 
@@ -12,7 +8,7 @@ mkdir /mnt/alma/DailyUpdate_automated
 cd /mnt/alma/DailyUpdate_automated
 
 # Copy down all the MRC files
-aws s3 sync s3://$ALMA_BUCKET/exlibris/Timdex/UPDATE/ . --exclude "*" --include "*.mrc"
+aws s3 sync s3://$ALMA_BUCKET/exlibris/Timdex/UPDATE/ . --delete --exclude "*" --include "*.mrc"
 
 # Remove the previous run's tmp file
 rm result.tmp
@@ -26,5 +22,7 @@ aws s3 cp result.tmp s3://$DIP_ALEPH_BUCKET/ALMA_UPDATE_EXPORT_$now.mrc
 #Test whether the file is valid, if it is, delete the files locally and from s3
 #sudo docker run mitlibraries/mario:latest ingest --source aleph --consumer silent s3://dip-aleph-s3-stage/ALMA_UPDATE_EXPORT_2021-06-24.mrc
 
-#rm *.mrc
-#aws s3 rm s3://$ALMA_BUCKET/exlibris/Timdex/FULL/
+aws s3 mv s3://$ALMA_BUCKET/exlibris/Timdex/UPDATE/ s3://$ALMA_BUCKET/exlibris/Timdex/UPDATE/ARCHIVE/ --exclude "*" --include "*.mrc" --recursive
+
+rm *.mrc
+


### PR DESCRIPTION
Summary -
These changes make the scripts "live" on alma-sftp-ec2-prod by removing the comments on the cron jobs.  We also archive the files when we're done with them by moving them to an archive folder.

These changes have been tested in prod and stage, but are not easily testable by the reviewer.

https://mitlibraries.atlassian.net/browse/IMP-2129