### PR TITLE
Llama refactor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.8'
           architecture: x64
       - name: Install
         run: |
@@ -27,7 +27,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.8'
           architecture: x64
       - name: Install
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,16 @@ bandit:
 	pipenv run bandit -r llama
 
 black:
-	pipenv run black --check --diff .
-	
+	pipenv run black --check --diff llama tests
+
 coveralls: test
 	pipenv run coveralls
 
 flake8:
-	pipenv run flake8 .
+	pipenv run flake8 llama tests
 
 isort:
-	pipenv run isort . --diff
-	
+	pipenv run isort llama tests --diff
+
 test:
 	pipenv run pytest --cov=llama

--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,7 @@ moto = {extras = ["s3"], version = "*"}
 freezegun = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.8"
 
 [scripts]
 llama = "python -c \"from llama.cli import cli; cli()\""

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c4a5354755f405cf6a1fe08575edf082b6e6117433449ea2d0ce0893ea8eea62"
+            "sha256": "567508defe7e0ce592e1b44bbe60af2631146b00864425e275de31f97bbd445a"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:8c3676239a35eba465e7df2df58ca400219729d4b732b7202f18caf0308ececa",
-                "sha256:bd6524c4ac854eb1fa31ab7040d405385f11231b84988b2a5c8e9896a3da0bf1"
+                "sha256:48241d2ca6074dd35411e1e72a4ca8ae5043e8e4aba0a9975a94af66382995da",
+                "sha256:dc44be94fa03245fd0cfff8a3fcc17d79283cfda9a39ae2e5cdedcd75749e089"
             ],
             "index": "pypi",
-            "version": "==1.18.13"
+            "version": "==1.18.15"
         },
         "botocore": {
             "hashes": [
-                "sha256:37c1c17326f9c81aba73efc6b496ccfe536822e576bc89ceee460dc18108f3a0",
-                "sha256:ce20da2dff6ab36ebee3b2efdf0bcc859ee1a7f8ec0d2ae3eaac5f50f6c729fd"
+                "sha256:5f9686f42fcc6df0eb3ca5804113135f06ae92a6010347665ca7670f1397bff1",
+                "sha256:90b50e321278223c794032ae1ded7dfebdc73c54cc3cbbf72648e4cfdf060529"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.13"
+            "version": "==1.21.15"
         },
         "certifi": {
             "hashes": [
@@ -46,14 +46,6 @@
             ],
             "markers": "python_version >= '3'",
             "version": "==2.0.4"
-        },
-        "freezegun": {
-            "hashes": [
-                "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3",
-                "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"
-            ],
-            "index": "pypi",
-            "version": "==1.1.0"
         },
         "idna": {
             "hashes": [
@@ -205,19 +197,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:8c3676239a35eba465e7df2df58ca400219729d4b732b7202f18caf0308ececa",
-                "sha256:bd6524c4ac854eb1fa31ab7040d405385f11231b84988b2a5c8e9896a3da0bf1"
+                "sha256:48241d2ca6074dd35411e1e72a4ca8ae5043e8e4aba0a9975a94af66382995da",
+                "sha256:dc44be94fa03245fd0cfff8a3fcc17d79283cfda9a39ae2e5cdedcd75749e089"
             ],
             "index": "pypi",
-            "version": "==1.18.13"
+            "version": "==1.18.15"
         },
         "botocore": {
             "hashes": [
-                "sha256:37c1c17326f9c81aba73efc6b496ccfe536822e576bc89ceee460dc18108f3a0",
-                "sha256:ce20da2dff6ab36ebee3b2efdf0bcc859ee1a7f8ec0d2ae3eaac5f50f6c729fd"
+                "sha256:5f9686f42fcc6df0eb3ca5804113135f06ae92a6010347665ca7670f1397bff1",
+                "sha256:90b50e321278223c794032ae1ded7dfebdc73c54cc3cbbf72648e4cfdf060529"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.13"
+            "version": "==1.21.15"
         },
         "certifi": {
             "hashes": [
@@ -389,6 +381,14 @@
             ],
             "index": "pypi",
             "version": "==3.9.2"
+        },
+        "freezegun": {
+            "hashes": [
+                "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3",
+                "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "gitdb": {
             "hashes": [
@@ -781,11 +781,11 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:056f0376bf5a6b182c513f9582c1e5b0487265eb6c48842b69aa9ca1cd5f640a",
-                "sha256:d60e681734099207a6add7a10326bc2ddd1fdc36c1b0f547d00ef73ac63739c2"
+                "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f",
+                "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "urllib3": {
             "hashes": [

--- a/cron.d/alma-exports
+++ b/cron.d/alma-exports
@@ -1,6 +1,0 @@
-# Cron jobs for alma exports
-# At 0853
-53 08 * * * root /mnt/alma/alma-scripts/scripts/Update-Export.sh 
-
-# At 0030 on the 2nd of the month
-30 0 2 * * root /mnt/alma/alma-scripts/scripts/Full-Export.sh

--- a/cron.d/timdex-exports
+++ b/cron.d/timdex-exports
@@ -1,0 +1,10 @@
+# Cron jobs for TIMDEX exports
+
+CURRENT_DATE=date +%Y%m
+
+# Daily at 0853
+53 08 * * * gituser cd /mnt/alma/alma-scripts && PATH=/usr/local/bin/pipenv:$PATH && pipenv run llama concat-timdex-export --export_type UPDATE >> /mnt/alma/logs/timdex-concat.log 2>&1
+
+# At 0030 on the 2nd of the month (runs on full export from the 1st of the
+# month)
+30 0 2 * * gituser cd /mnt/alma/alma-scripts && PATH=/usr/local/bin/pipenv:$PATH && pipenv run llama concat-timdex-export --export_type FULL --date "$(${CURRENT_DATE})01" >> /mnt/alma/logs/timdex-concat.log 2>&1

--- a/llama/s3.py
+++ b/llama/s3.py
@@ -1,28 +1,39 @@
+from boto3 import client
 from s3_concat import S3Concat
 
 
-def concatenate_files(date, session, bucket, key_prefix, output_filename):
-    """Concatenates files with the provided key_prefix in the provided bucket in a
-    random order"""
-    job = S3Concat(
-        bucket,
-        output_filename,
-        None,
-        session=session,
-    )
-    job.add_files(f"{key_prefix}{date}")
-    job.concat()
+class S3:
+    """An S3 class that provides a generic boto3 s3 client for interacting with S3
+    objects, along with specific S3 functionality necessary for llama scripts"""
 
+    def __init__(self):
+        self.client = client("s3")
 
-def move_s3_file(client, old_bucket, old_key, new_bucket, new_key):
-    """Duplicate behavior of AWS CLI mv command by copying the source object to a new key
-    and then deleting the source object."""
-    client.copy_object(
-        Bucket=new_bucket,
-        CopySource=f"{old_bucket}/{old_key}",
-        Key=new_key,
-    )
-    client.delete_object(
-        Bucket=old_bucket,
-        Key=old_key,
-    )
+    def concatenate_files(self, bucket, prefix, output_filename):
+        """Concatenate all files with the provided prefix within an S3 bucket into a new
+        file with the provided output file name. The source files may be concatenated
+        in a random order, and the output file will be created in the same bucket as
+        the source files."""
+        job = S3Concat(
+            bucket=bucket,
+            key=output_filename,
+            min_file_size=None,
+            s3_client=self.client,
+        )
+        job.add_files(prefix)
+        job.concat()
+
+    def move_file(self, key, source_bucket, destination_bucket):
+        """Duplicate behavior of AWS CLI mv command by copying the object from the
+        source bucket to a destination bucket and then deleting the object from the
+        source bucket. Note that if the provided key already exists in the destination
+        bucket, this will replace that object with the object from the source bucket."""
+        self.client.copy_object(
+            Bucket=destination_bucket,
+            CopySource=f"{source_bucket}/{key}",
+            Key=key,
+        )
+        self.client.delete_object(
+            Bucket=source_bucket,
+            Key=key,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,9 +28,8 @@ def runner():
 
 
 @pytest.fixture(scope="function")
-def s3_session(aws_credentials):
+def mocked_s3(aws_credentials):
     with mock_s3():
-        session = boto3.session.Session()
         s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket="ils-sftp")
         s3.put_object(
@@ -54,4 +53,4 @@ def s3_session(aws_credentials):
             Body="MARC 004",
         )
         s3.create_bucket(Bucket="dip-ils-bucket")
-        yield session
+        yield s3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 from click.testing import CliRunner
 from moto import mock_s3
 
+from llama.s3 import S3
+
 
 @pytest.fixture(scope="function")
 def aws_credentials():
@@ -20,11 +22,6 @@ def bucket_env():
     """Mocked AWS Credentials for moto."""
     os.environ["ALMA_BUCKET"] = "ils-sftp"
     os.environ["DIP_ALEPH_BUCKET"] = "dip-ils-bucket"
-
-
-@pytest.fixture(scope="function")
-def runner():
-    return CliRunner()
 
 
 @pytest.fixture(scope="function")
@@ -54,3 +51,13 @@ def mocked_s3(aws_credentials):
         )
         s3.create_bucket(Bucket="dip-ils-bucket")
         yield s3
+
+
+@pytest.fixture(scope="function")
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(scope="function")
+def s3():
+    return S3()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,9 @@
-import os
-
 from freezegun import freeze_time
 
 from llama.cli import cli
-from llama.s3 import S3
 
 
-def test_concat_timdex_export_all_options_provided_success(mocked_s3, runner):
-    s3 = S3()
+def test_concat_timdex_export_all_options_provided_success(mocked_s3, runner, s3):
     assert len(s3.client.list_objects(Bucket="ils-sftp")["Contents"]) == 4
     assert "Contents" not in s3.client.list_objects(Bucket="dip-ils-bucket")
     result = runner.invoke(
@@ -36,10 +32,9 @@ def test_concat_timdex_export_all_options_provided_success(mocked_s3, runner):
 
 
 @freeze_time("2021-01-01")
-def test_concat_timdex_export_no_options_provided_success(mocked_s3, runner):
-    os.environ["ALMA_BUCKET"] = "ils-sftp"
-    os.environ["DIP_ALEPH_BUCKET"] = "dip-ils-bucket"
-    s3 = S3()
+def test_concat_timdex_export_no_options_provided_success(
+    bucket_env, mocked_s3, runner, s3
+):
     assert len(s3.client.list_objects(Bucket="ils-sftp")["Contents"]) == 4
     assert "Contents" not in s3.client.list_objects(Bucket="dip-ils-bucket")
     result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,48 +1,15 @@
+import os
+
 from freezegun import freeze_time
 
 from llama.cli import cli
+from llama.s3 import S3
 
 
-@freeze_time("2021-01-01")
-def test_concat_timdex_export(s3_session, bucket_env, runner):
-    # today's date
-    assert len(s3_session.client("s3").list_objects(Bucket="ils-sftp")["Contents"]) == 4
-    assert "Contents" not in s3_session.client("s3").list_objects(
-        Bucket="dip-ils-bucket"
-    )
-    result = runner.invoke(
-        cli,
-        [
-            "concat-timdex-export",
-            "--export_type",
-            "UPDATE",
-        ],
-    )
-    assert result.exit_code == 0
-    concatenated_file = s3_session.client("s3").get_object(
-        Bucket="dip-ils-bucket", Key="ALMA_UPDATE_EXPORT_20210101.mrc"
-    )
-    assert concatenated_file["Body"].read() == b"MARC 001MARC 002"
-
-    # past date
-    assert len(s3_session.client("s3").list_objects(Bucket="ils-sftp")["Contents"]) == 4
-    result = runner.invoke(
-        cli,
-        [
-            "concat-timdex-export",
-            "--export_type",
-            "UPDATE",
-            "--date",
-            "20201012",
-        ],
-    )
-    assert result.exit_code == 0
-    concatenated_file = s3_session.client("s3").get_object(
-        Bucket="dip-ils-bucket", Key="ALMA_UPDATE_EXPORT_20201012.mrc"
-    )
-    assert concatenated_file["Body"].read() == b"MARC 003MARC 004"
-
-    # no files matching specified date
+def test_concat_timdex_export_all_options_provided_success(mocked_s3, runner):
+    s3 = S3()
+    assert len(s3.client.list_objects(Bucket="ils-sftp")["Contents"]) == 4
+    assert "Contents" not in s3.client.list_objects(Bucket="dip-ils-bucket")
     result = runner.invoke(
         cli,
         [
@@ -54,12 +21,75 @@ def test_concat_timdex_export(s3_session, bucket_env, runner):
             "--destination_bucket",
             "dip-ils-bucket",
             "--date",
-            "19560101",
+            "20210101",
         ],
     )
-    exception_text = (
-        "No files with key beginning: "
-        "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__19560101\n"
+    assert result.exit_code == 0
+    assert (
+        "Concatenated file ALMA_UPDATE_EXPORT_20210101.mrc succesfully created"
+        in result.output
     )
-    assert result.output == exception_text
+    concatenated_file = s3.client.get_object(
+        Bucket="dip-ils-bucket", Key="ALMA_UPDATE_EXPORT_20210101.mrc"
+    )
+    assert concatenated_file["Body"].read() == b"MARC 001MARC 002"
+
+
+@freeze_time("2021-01-01")
+def test_concat_timdex_export_no_options_provided_success(mocked_s3, runner):
+    os.environ["ALMA_BUCKET"] = "ils-sftp"
+    os.environ["DIP_ALEPH_BUCKET"] = "dip-ils-bucket"
+    s3 = S3()
+    assert len(s3.client.list_objects(Bucket="ils-sftp")["Contents"]) == 4
+    assert "Contents" not in s3.client.list_objects(Bucket="dip-ils-bucket")
+    result = runner.invoke(
+        cli,
+        [
+            "concat-timdex-export",
+            "--export_type",
+            "UPDATE",
+        ],
+    )
+    assert result.exit_code == 0
+    concatenated_file = s3.client.get_object(
+        Bucket="dip-ils-bucket", Key="ALMA_UPDATE_EXPORT_20210101.mrc"
+    )
+    assert concatenated_file["Body"].read() == b"MARC 001MARC 002"
+
+
+def test_concat_timdex_export_key_error(mocked_s3, runner):
+    result = runner.invoke(
+        cli,
+        [
+            "concat-timdex-export",
+            "--export_type",
+            "UPDATE",
+            "--source_bucket",
+            "ils-sftp",
+            "--destination_bucket",
+            "dip-ils-bucket",
+            "--date",
+            "20211212",
+        ],
+    )
     assert result.exit_code == 1
+    assert "No files found in bucket ils-sftp with key prefix" in result.output
+
+
+def test_concat_timdex_export_bucket_error(mocked_s3, runner):
+    result = runner.invoke(
+        cli,
+        [
+            "concat-timdex-export",
+            "--export_type",
+            "UPDATE",
+            "--source_bucket",
+            "fake-bucket",
+            "--destination_bucket",
+            "dip-ils-bucket",
+            "--date",
+            "20210101",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "One or more supplied buckets does not exist" in result.output

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,48 +1,102 @@
-from llama import s3
+import pytest
+
+from llama.s3 import S3
 
 
-def test_concatenate_files(s3_session, bucket_env):
-    # today's date
+def test_concatenate_files_no_files_with_prefix_exist(mocked_s3):
+    s3 = S3()
+    with pytest.raises(KeyError):
+        s3.concatenate_files("ils-sftp", "fake_prefix", "result.mrc")
+
+
+def test_concatenate_files_bucket_does_not_exist(mocked_s3):
+    s3 = S3()
+    with pytest.raises(s3.client.exceptions.NoSuchBucket):
+        s3.concatenate_files(
+            "fake_bucket",
+            "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101",
+            "result.mrc",
+        )
+
+
+def test_concatenate_files_output_file_already_exists(mocked_s3):
+    s3 = S3()
     s3.concatenate_files(
-        "20210101",
-        s3_session,
         "ils-sftp",
-        "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__",
-        "ALMA_UPDATE_EXPORT_20210101.mrc",
+        "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101",
+        "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20201012_marc1.mrc",
     )
-    concatenated_file = s3_session.client("s3").get_object(
-        Bucket="ils-sftp", Key="ALMA_UPDATE_EXPORT_20210101.mrc"
+    concatenated_file = s3.client.get_object(
+        Bucket="ils-sftp",
+        Key="exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20201012_marc1.mrc",
     )
     assert concatenated_file["Body"].read() == b"MARC 001MARC 002"
 
-    # past date
+
+def test_concatenate_files_includes_expected_content(mocked_s3):
+    s3 = S3()
     s3.concatenate_files(
-        "20201012",
-        s3_session,
         "ils-sftp",
-        "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__",
-        "ALMA_UPDATE_EXPORT_20201012.mrc",
+        "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101",
+        "result.mrc",
     )
-    concatenated_file = s3_session.client("s3").get_object(
-        Bucket="ils-sftp", Key="ALMA_UPDATE_EXPORT_20201012.mrc"
-    )
-    assert concatenated_file["Body"].read() == b"MARC 003MARC 004"
+    concatenated_file = s3.client.get_object(Bucket="ils-sftp", Key="result.mrc")
+    assert concatenated_file["Body"].read() == b"MARC 001MARC 002"
 
 
-def test_move_s3_file(s3_session, bucket_env):
-    assert len(s3_session.client("s3").list_objects(Bucket="ils-sftp")["Contents"]) == 4
-    assert "Contents" not in s3_session.client("s3").list_objects(
-        Bucket="dip-ils-bucket"
+def test_move_file_key_does_not_exist(mocked_s3):
+    s3 = S3()
+    with pytest.raises(s3.client.exceptions.ClientError):
+        s3.move_file("fake_key", "ils-sftp", "dip-ils-bucket")
+
+
+def test_move_file_source_bucket_does_not_exist(mocked_s3):
+    s3 = S3()
+    with pytest.raises(s3.client.exceptions.NoSuchBucket):
+        s3.move_file(
+            "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
+            "fake_bucket",
+            "dip-ils-bucket",
+        )
+
+
+def test_move_file_destination_bucket_does_not_exist(mocked_s3):
+    s3 = S3()
+    with pytest.raises(s3.client.exceptions.NoSuchBucket):
+        s3.move_file(
+            "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
+            "ils-sftp",
+            "fake_bucket",
+        )
+
+
+def test_move_file_replaces_if_key_already_exists_in_destination_bucket(mocked_s3):
+    s3 = S3()
+    s3.client.put_object(
+        Bucket="dip-ils-bucket",
+        Key="exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
+        Body="I am already here!",
     )
-    s3.move_s3_file(
-        s3_session.client("s3"),
-        "ils-sftp",
+    s3.move_file(
         "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
+        "ils-sftp",
         "dip-ils-bucket",
-        "ARCHIVE/ALMA_UPDATE_EXPORT__20201012_marc1.mrc",
     )
-    assert len(s3_session.client("s3").list_objects(Bucket="ils-sftp")["Contents"]) == 3
-    assert (
-        len(s3_session.client("s3").list_objects(Bucket="dip-ils-bucket")["Contents"])
-        == 1
+    replaced_file = s3.client.get_object(
+        Bucket="dip-ils-bucket",
+        Key="exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
     )
+    assert replaced_file["Body"].read() == b"MARC 001"
+
+
+def test_move_file_copies_and_deletes_file(mocked_s3):
+    s3 = S3()
+    assert len(s3.client.list_objects(Bucket="ils-sftp")["Contents"]) == 4
+    assert "Contents" not in s3.client.list_objects(Bucket="dip-ils-bucket")
+    s3.move_file(
+        "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
+        "ils-sftp",
+        "dip-ils-bucket",
+    )
+    assert len(s3.client.list_objects(Bucket="ils-sftp")["Contents"]) == 3
+    assert len(s3.client.list_objects(Bucket="dip-ils-bucket")["Contents"]) == 1

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,16 +1,12 @@
 import pytest
 
-from llama.s3 import S3
 
-
-def test_concatenate_files_no_files_with_prefix_exist(mocked_s3):
-    s3 = S3()
+def test_concatenate_files_no_files_with_prefix_exist(mocked_s3, s3):
     with pytest.raises(KeyError):
         s3.concatenate_files("ils-sftp", "fake_prefix", "result.mrc")
 
 
-def test_concatenate_files_bucket_does_not_exist(mocked_s3):
-    s3 = S3()
+def test_concatenate_files_bucket_does_not_exist(mocked_s3, s3):
     with pytest.raises(s3.client.exceptions.NoSuchBucket):
         s3.concatenate_files(
             "fake_bucket",
@@ -19,8 +15,7 @@ def test_concatenate_files_bucket_does_not_exist(mocked_s3):
         )
 
 
-def test_concatenate_files_output_file_already_exists(mocked_s3):
-    s3 = S3()
+def test_concatenate_files_output_file_already_exists(mocked_s3, s3):
     s3.concatenate_files(
         "ils-sftp",
         "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101",
@@ -33,8 +28,7 @@ def test_concatenate_files_output_file_already_exists(mocked_s3):
     assert concatenated_file["Body"].read() == b"MARC 001MARC 002"
 
 
-def test_concatenate_files_includes_expected_content(mocked_s3):
-    s3 = S3()
+def test_concatenate_files_includes_expected_content(mocked_s3, s3):
     s3.concatenate_files(
         "ils-sftp",
         "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101",
@@ -44,14 +38,12 @@ def test_concatenate_files_includes_expected_content(mocked_s3):
     assert concatenated_file["Body"].read() == b"MARC 001MARC 002"
 
 
-def test_move_file_key_does_not_exist(mocked_s3):
-    s3 = S3()
+def test_move_file_key_does_not_exist(mocked_s3, s3):
     with pytest.raises(s3.client.exceptions.ClientError):
         s3.move_file("fake_key", "ils-sftp", "dip-ils-bucket")
 
 
-def test_move_file_source_bucket_does_not_exist(mocked_s3):
-    s3 = S3()
+def test_move_file_source_bucket_does_not_exist(mocked_s3, s3):
     with pytest.raises(s3.client.exceptions.NoSuchBucket):
         s3.move_file(
             "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
@@ -60,8 +52,7 @@ def test_move_file_source_bucket_does_not_exist(mocked_s3):
         )
 
 
-def test_move_file_destination_bucket_does_not_exist(mocked_s3):
-    s3 = S3()
+def test_move_file_destination_bucket_does_not_exist(mocked_s3, s3):
     with pytest.raises(s3.client.exceptions.NoSuchBucket):
         s3.move_file(
             "exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
@@ -70,8 +61,7 @@ def test_move_file_destination_bucket_does_not_exist(mocked_s3):
         )
 
 
-def test_move_file_replaces_if_key_already_exists_in_destination_bucket(mocked_s3):
-    s3 = S3()
+def test_move_file_replaces_if_key_already_exists_in_destination_bucket(mocked_s3, s3):
     s3.client.put_object(
         Bucket="dip-ils-bucket",
         Key="exlibris/Timdex/UPDATE/ALMA_UPDATE_EXPORT__20210101_marc1.mrc",
@@ -89,8 +79,7 @@ def test_move_file_replaces_if_key_already_exists_in_destination_bucket(mocked_s
     assert replaced_file["Body"].read() == b"MARC 001"
 
 
-def test_move_file_copies_and_deletes_file(mocked_s3):
-    s3 = S3()
+def test_move_file_copies_and_deletes_file(mocked_s3, s3):
     assert len(s3.client.list_objects(Bucket="ils-sftp")["Contents"]) == 4
     assert "Contents" not in s3.client.list_objects(Bucket="dip-ils-bucket")
     s3.move_file(


### PR DESCRIPTION
#### What does this PR do?
- Refactors the llama `cli.py` and `s3.py` modules to streamline existing code and make it more reusable
- Adds more robust testing for all known error states
- Updates the cron jobs for daily and monthly export concatenation to use the new llama cli
- Sends the cron-initiated TIMDEX export concat output to a log file for review

#### How can a reviewer manually see the effects of these changes?
Run the command `pipenv run llama concat-timdex-export --export_type UPDATE --date 20210804` on stage and check the dip bucket for success. Can also update the time of the daily update cron job to a few minutes from now to see it run via cron. Will need to make sure there are correctly-named update files with today's date in the staging alma bucket for that to work.

#### Includes new or updated dependencies?
NO