### PR TITLE
Create automated daily email of credit card slips to Tech Services staff

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ requests = "*"
 lxml = "*"
 boto3 = "*"
 s3-concat = "*"
+defusedxml = "*"
 
 [dev-packages]
 black = "==21.7b0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "567508defe7e0ce592e1b44bbe60af2631146b00864425e275de31f97bbd445a"
+            "sha256": "ff55d9b100a6e1565924979cd7ae9e459c55ebad980a191423439850da5432b0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:48241d2ca6074dd35411e1e72a4ca8ae5043e8e4aba0a9975a94af66382995da",
-                "sha256:dc44be94fa03245fd0cfff8a3fcc17d79283cfda9a39ae2e5cdedcd75749e089"
+                "sha256:5e5f60ece9b73d48f668bef56ddcde716f013b48a62fdf9c5eac9512a5981136",
+                "sha256:69a5ebbd5fda6742d20fd536cd9b2927f2eaa8dde84ad529fe816231afcf9c68"
             ],
             "index": "pypi",
-            "version": "==1.18.15"
+            "version": "==1.18.17"
         },
         "botocore": {
             "hashes": [
-                "sha256:5f9686f42fcc6df0eb3ca5804113135f06ae92a6010347665ca7670f1397bff1",
-                "sha256:90b50e321278223c794032ae1ded7dfebdc73c54cc3cbbf72648e4cfdf060529"
+                "sha256:5b665142bdb2c30fc86b15bc48dd8b74c9cac69dc3e20b6d8f79cb60ff368797",
+                "sha256:a0d64369857d86b3a6d01b0c5933671c2394584311ce3af702271ba221b09afa"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.15"
+            "version": "==1.21.17"
         },
         "certifi": {
             "hashes": [
@@ -46,6 +46,14 @@
             ],
             "markers": "python_version >= '3'",
             "version": "==2.0.4"
+        },
+        "defusedxml": {
+            "hashes": [
+                "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69",
+                "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            ],
+            "index": "pypi",
+            "version": "==0.7.1"
         },
         "idna": {
             "hashes": [
@@ -197,19 +205,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:48241d2ca6074dd35411e1e72a4ca8ae5043e8e4aba0a9975a94af66382995da",
-                "sha256:dc44be94fa03245fd0cfff8a3fcc17d79283cfda9a39ae2e5cdedcd75749e089"
+                "sha256:5e5f60ece9b73d48f668bef56ddcde716f013b48a62fdf9c5eac9512a5981136",
+                "sha256:69a5ebbd5fda6742d20fd536cd9b2927f2eaa8dde84ad529fe816231afcf9c68"
             ],
             "index": "pypi",
-            "version": "==1.18.15"
+            "version": "==1.18.17"
         },
         "botocore": {
             "hashes": [
-                "sha256:5f9686f42fcc6df0eb3ca5804113135f06ae92a6010347665ca7670f1397bff1",
-                "sha256:90b50e321278223c794032ae1ded7dfebdc73c54cc3cbbf72648e4cfdf060529"
+                "sha256:5b665142bdb2c30fc86b15bc48dd8b74c9cac69dc3e20b6d8f79cb60ff368797",
+                "sha256:a0d64369857d86b3a6d01b0c5933671c2394584311ce3af702271ba221b09afa"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.15"
+            "version": "==1.21.17"
         },
         "certifi": {
             "hashes": [
@@ -339,7 +347,7 @@
                 "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
                 "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==5.5"
         },
         "coveralls": {
@@ -361,6 +369,8 @@
                 "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1",
                 "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177",
                 "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250",
+                "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586",
+                "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3",
                 "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca",
                 "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d",
                 "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"
@@ -413,6 +423,14 @@
             ],
             "markers": "python_version >= '3'",
             "version": "==3.2"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:0645585859e9a6689c523927a5032f2ba5919f1f7d0e84bd4533312320de1ff9",
+                "sha256:51c6635429c77cf1ae634c997ff9e53ca3438b495f10a55ba28594dd69764a8b"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.6.3"
         },
         "iniconfig": {
             "hashes": [
@@ -505,11 +523,11 @@
                 "s3"
             ],
             "hashes": [
-                "sha256:4ea538fe090b964c22bb98a6f87d3c589eaf754893d297d58b74dedb94d4448c",
-                "sha256:ab9f7114bf5b60e9d3ae518c0694bf53e111a5c0c195b19e89707c97ab71b53c"
+                "sha256:210634dac5943dfa0db59107d1b10be9897ae37b55682f5c3808a0e0b289321f",
+                "sha256:b0b5a9179bcb4833fd2f67e31e44004d7ec7687106ab22150cbeac7e6e97b725"
             ],
             "index": "pypi",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         },
         "mypy-extensions": {
             "hashes": [
@@ -726,11 +744,11 @@
         },
         "responses": {
             "hashes": [
-                "sha256:18a5b88eb24143adbf2b4100f328a2f5bfa72fbdacf12d97d41f07c26c45553d",
-                "sha256:b54067596f331786f5ed094ff21e8d79e6a1c68ef625180a7d34808d6f36c11b"
+                "sha256:9476775d856d3c24ae660bbebe29fb6d789d4ad16acd723efbfb6ee20990b899",
+                "sha256:d8d0f655710c46fd3513b9202a7f0dcedd02ca0f8cf4976f27fa8ab5b81e656d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.13.3"
+            "version": "==0.13.4"
         },
         "s3transfer": {
             "hashes": [
@@ -809,6 +827,14 @@
                 "sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"
             ],
             "version": "==0.12.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3",
+                "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.5.0"
         }
     }
 }

--- a/config/credit_card_slip_template.xml
+++ b/config/credit_card_slip_template.xml
@@ -1,0 +1,130 @@
+<ccslip>
+    <p align="center">
+      <b>MIT Libraries Credit Card Purchase</b><br/>
+      Monograph Acquisitions, Rm. NE36-6101</p>
+    <br/>
+    <br/>
+    <table border="0" width="100%" align="left">
+      <tr>
+        <td colspan="2">
+          <u>CHARGE INFORMATION</u>
+        </td>
+      </tr>
+      <tr>
+        <td align="left">Date:</td>
+        <td class="po_date" align="left">20210518</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="left">Cardholder:</td>
+        <td class="cardholder" align="left"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="left">Vendor code:
+        </td>
+        <td class="vendor" align="left"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="left">Account 1:
+        </td>
+        <td class="account_1" align="left"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="left">Account 2:
+        </td>
+        <td class="account_2" align="left"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><br/></td>
+      </tr>
+      <tr>
+        <td>PO Line #:</td>
+        <td>TITLE:</td>
+        <td>PRICE</td>
+      </tr>
+      <tr>
+        <td class="poline"></td>
+        <td class="item_title"></td>
+        <td class="price"></td>
+      </tr>
+      <tr>
+        <td><br/></td>
+      </tr>
+      <tr>
+        <td></td>
+        <td align="right">Transaction fee:
+        </td>
+        <td>__________</td>
+      </tr>
+      <tr>
+        <td></td>
+        <td align="right">TOTAL DUE:
+        </td>
+        <td class="price"></td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <u>SAP INFORMATION</u>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">SAP document #:</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">Date posted in SAP:</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">Verified by:</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">Verified date:</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><br/></td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <u>ALMA INVOICE INFORMATION</u>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td class="invoice_num" colspan="2"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td style="padding-left:30px;" colspan="3">Inv #: Date charged + 1st 3 letters of title: YYMMDD "xxx")</td>
+      </tr>
+      <tr>
+        <td style="padding-left:30px;" class="credit_memo_num" colspan="3">For Credit Memo #, use Invoice # + CRE (YYMMDD"XXX"CRE)</td>
+      </tr>
+      <tr>
+        <td colspan="2">Use Charge Date above for Invoice Date.</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><br/></td>
+      </tr>
+      <tr>
+        <td colspan="2">Date entered in Alma:
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">Entered by:
+        </td>
+        <td></td>
+      </tr>
+    </table>
+    <hr class="pb"/>
+    <p style="page-break-before: always" />
+</ccslip>

--- a/llama/cli.py
+++ b/llama/cli.py
@@ -31,7 +31,8 @@ def cli(ctx):
 @click.option(
     "--recipient_email",
     required=True,
-    help="The email address receiving the credit card slips.",
+    multiple=True,
+    help="The email address receiving the credit card slips. Re",
 )
 @click.pass_context
 def cc_slips(ctx, date, source_email, recipient_email):
@@ -45,7 +46,7 @@ def cc_slips(ctx, date, source_email, recipient_email):
             date,
             credit_card_slips_xml,
             source_email,
-            recipient_email,
+            list(recipient_email),
         )
     except ClientError as e:
         click.echo(e.response["Error"]["Message"])

--- a/llama/credit_card_slips.py
+++ b/llama/credit_card_slips.py
@@ -127,9 +127,10 @@ def load_xml_template(xml_file):
 
 
 def send_credit_card_slips_email(
-    ses_client, date, attachment_content, source_email, recipient_email
+    ses_client, date, attachment_content, source_email, recipients
 ):
-    """Send email with credit card slips as an attached file."""
+    """Send email with credit card slips as an attached file. Recipients parameter must
+    be a list and not a str."""
     message = MIMEMultipart()
     message["Subject"] = f"Credit card slips {date}"
     attachment_object = MIMEApplication(attachment_content)
@@ -139,7 +140,7 @@ def send_credit_card_slips_email(
     message.attach(attachment_object)
     response = ses_client.send_raw_email(
         Source=source_email,
-        Destinations=[recipient_email],
+        Destinations=recipients,
         RawMessage={
             "Data": message.as_string(),
         },

--- a/llama/credit_card_slips.py
+++ b/llama/credit_card_slips.py
@@ -1,6 +1,4 @@
 import os
-from email.mime.application import MIMEApplication
-from email.mime.multipart import MIMEMultipart
 
 import requests
 from defusedxml import ElementTree as ET
@@ -124,25 +122,3 @@ def load_xml_template(xml_file):
     tree = ET.parse(xml_file)
     root = tree.getroot()
     return root
-
-
-def send_credit_card_slips_email(
-    ses_client, date, attachment_content, source_email, recipients
-):
-    """Send email with credit card slips as an attached file. Recipients parameter must
-    be a list and not a str."""
-    message = MIMEMultipart()
-    message["Subject"] = f"Credit card slips {date}"
-    attachment_object = MIMEApplication(attachment_content)
-    attachment_object.add_header(
-        "Content-Disposition", "attachment", filename=f"{date}_credit_card_slips.htm"
-    )
-    message.attach(attachment_object)
-    response = ses_client.send_raw_email(
-        Source=source_email,
-        Destinations=recipients,
-        RawMessage={
-            "Data": message.as_string(),
-        },
-    )
-    return response

--- a/llama/credit_card_slips.py
+++ b/llama/credit_card_slips.py
@@ -1,0 +1,147 @@
+import os
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+
+import requests
+from defusedxml import ElementTree as ET
+
+
+def create_credit_card_slips(date):
+    """Create credit card slips XML string."""
+    alma_json_headers = {
+        "accept": "application/json",
+        "content-type": "application/json",
+        "Authorization": f'apikey {os.environ["API_KEY"]}',
+    }
+
+    po_payload = {"status": "ACTIVE", "limit": "100", "offset": 0}
+
+    credit_card_slips_xml = ET.fromstring("<html></html>")
+
+    po_lines = ""
+    while po_lines != []:
+        response = requests.get(
+            f'{os.environ["API_URL"]}acq/po-lines',
+            params=po_payload,
+            headers=alma_json_headers,
+        ).json()
+        po_lines = response.get("po_line", [])
+        for po_line_stub in [p for p in po_lines if p["created_date"] == f"{date}Z"]:
+            po_line_record = requests.get(
+                f'{os.environ["API_URL"]}acq/po-lines/{po_line_stub["number"]}',
+                headers=alma_json_headers,
+            ).json()
+            if (
+                "acquisition_method" in po_line_record
+                and po_line_record["acquisition_method"]["desc"] == "Credit Card"
+            ):
+                value_dict = create_dict_from_po_line_record(
+                    po_line_record, alma_json_headers
+                )
+                credit_card_slip = load_xml_template(
+                    "config/credit_card_slip_template.xml"
+                )
+                for k, v in value_dict.items():
+                    for element in credit_card_slip.findall(f'.//td[@class="{k}"]'):
+                        element.text = v
+                credit_card_slips_xml.append(credit_card_slip)
+        po_payload["offset"] += 100
+    credit_card_slips_xml_string = ET.tostring(
+        credit_card_slips_xml, encoding="unicode", method="xml"
+    )
+    return credit_card_slips_xml_string
+
+
+def create_dict_from_po_line_record(po_line_record, alma_json_headers):
+    """Create dict of the required data for credit card slips from an Alma PO line
+    record. The keys of the dict map to the appropriate element classes in the XML
+    template."""
+    value_dict = {}
+    value_dict["vendor"] = po_line_record["vendor_account"]
+    value_dict["poline"] = po_line_record["number"]
+
+    title = get_po_title(po_line_record)
+    value_dict["item_title"] = title
+
+    price = format(float(po_line_record["price"]["sum"]), ".2f")
+    value_dict["price"] = f"${price}"
+
+    # Stakeholder requested format of date
+    po_line_created_date = "".join(
+        filter(str.isdigit, po_line_record["created_date"][2:])
+    )
+    value_dict["po_date"] = po_line_created_date
+    value_dict["invoice_num"] = f"Invoice #: {po_line_created_date}{title[:3].upper()}"
+
+    fund_code_1 = po_line_record["fund_distribution"][0]["fund_code"]["value"]
+    value_dict["account_1"] = get_account_from_fund_code(fund_code_1, alma_json_headers)
+    if len(po_line_record["fund_distribution"]) > 1:
+        fund_code_2 = po_line_record["fund_distribution"][1]["fund_code"]["value"]
+        value_dict["account_2"] = get_account_from_fund_code(
+            fund_code_2, alma_json_headers
+        )
+    value_dict["cardholder"] = get_cardholder_from_notes(po_line_record)
+    return value_dict
+
+
+def get_account_from_fund_code(fund_code, alma_json_headers):
+    """Get account number based on a fund code."""
+    if fund_code == "":
+        account = "No fund code"
+    else:
+        fund_payload = {"q": f"fund_code~{fund_code}"}
+        response = requests.get(
+            f'{os.environ["API_URL"]}acq/funds',
+            params=fund_payload,
+            headers=alma_json_headers,
+        ).json()
+        account = response["fund"][0]["external_id"]
+    return account
+
+
+def get_cardholder_from_notes(po_line_record):
+    """Get cardholder note with CC- prefix from Alma PO line record."""
+    cardholder = "No cardholder note"
+    for note in [
+        n
+        for n in po_line_record["note"]
+        if "note" in po_line_record and n["note_text"].startswith("CC-")
+    ]:
+        cardholder = note["note_text"][3:]
+    return cardholder
+
+
+def get_po_title(po_line_record):
+    """Retrieve title from Alma PO line record. PO line records store the title as a
+    null value if no item is attached but a string is required for the invoice number."""
+    title = po_line_record["resource_metadata"]["title"]
+    title = "Unknown title" if title is None else title
+    return title
+
+
+def load_xml_template(xml_file):
+    """Create an Elementree object from an XML file template."""
+    tree = ET.parse(xml_file)
+    root = tree.getroot()
+    return root
+
+
+def send_credit_card_slips_email(
+    ses_client, date, attachment_content, source_email, recipient_email
+):
+    """Send email with credit card slips as an attached file."""
+    message = MIMEMultipart()
+    message["Subject"] = f"Credit card slips {date}"
+    attachment_object = MIMEApplication(attachment_content)
+    attachment_object.add_header(
+        "Content-Disposition", "attachment", filename=f"{date}_credit_card_slips.htm"
+    )
+    message.attach(attachment_object)
+    response = ses_client.send_raw_email(
+        Source=source_email,
+        Destinations=[recipient_email],
+        RawMessage={
+            "Data": message.as_string(),
+        },
+    )
+    return response

--- a/llama/ses.py
+++ b/llama/ses.py
@@ -1,0 +1,32 @@
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+
+from boto3 import client
+
+
+class SES:
+    """An SES class that provides a generic boto3 SES client for interacting with SE
+    objects, along with specific SES functionality necessary for llama scripts"""
+
+    def __init__(self):
+        self.client = client("ses", region_name="us-east-1")
+
+    def send_email(
+        self, subject, attachment_content, attachment_name, source_email, recipients
+    ):
+        """Send email via SES. Recipients parameter must be a list and not a str."""
+        message = MIMEMultipart()
+        message["Subject"] = subject
+        attachment_object = MIMEApplication(attachment_content)
+        attachment_object.add_header(
+            "Content-Disposition", "attachment", filename=attachment_name
+        )
+        message.attach(attachment_object)
+        response = self.client.send_raw_email(
+            Source=source_email,
+            Destinations=recipients,
+            RawMessage={
+                "Data": message.as_string(),
+            },
+        )
+        return response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,23 @@
 import os
+from unittest import mock
 
 import boto3
 import pytest
+import requests_mock
 from click.testing import CliRunner
 from moto import mock_s3
 
 from llama.s3 import S3
+
+
+@pytest.fixture()
+def alma_json_headers():
+    alma_json_headers = {
+        "accept": "application/json",
+        "content-type": "application/json",
+        "Authorization": "apikey ABC123",
+    }
+    return alma_json_headers
 
 
 @pytest.fixture(scope="function")
@@ -22,6 +34,34 @@ def bucket_env():
     """Mocked AWS Credentials for moto."""
     os.environ["ALMA_BUCKET"] = "ils-sftp"
     os.environ["DIP_ALEPH_BUCKET"] = "dip-ils-bucket"
+
+
+@pytest.fixture()
+def mocked_alma(po_line_record_all_fields):
+    with requests_mock.Mocker() as m:
+        fund_code_record_abc = {"fund": [{"external_id": "456"}]}
+        fund_code_record_def = {"fund": [{"external_id": "789"}]}
+        po_lines = {"po_line": [{"number": "POL-789", "created_date": "2021-05-13Z"}]}
+        m.get("http://example.com/acq/funds?q=fund_code~ABC", json=fund_code_record_abc)
+        m.get("http://example.com/acq/funds?q=fund_code~DEF", json=fund_code_record_def)
+        m.get(
+            "http://example.com/acq/po-lines?status=ACTIVE&limit=100&offset=0",
+            json=po_lines,
+        )
+        m.get(
+            "http://example.com/acq/po-lines?status=ACTIVE&limit=100&offset=100",
+            json={},
+        )
+        m.get("http://example.com/acq/po-lines/POL-789", json=po_line_record_all_fields)
+        yield m
+
+
+@pytest.fixture()
+def mocked_alma_env_vars():
+    with mock.patch.dict(
+        os.environ, {"API_URL": "http://example.com/", "API_KEY": "abc123"}
+    ):
+        yield
 
 
 @pytest.fixture(scope="function")
@@ -51,6 +91,55 @@ def mocked_s3(aws_credentials):
         )
         s3.create_bucket(Bucket="dip-ils-bucket")
         yield s3
+
+
+@pytest.fixture()
+def po_line_record_all_fields():
+    """A PO line record with all fields present."""
+    po_line_record_all = {
+        "acquisition_method": {"desc": "Credit Card"},
+        "vendor_account": "Corporation",
+        "number": "POL-123",
+        "resource_metadata": {"title": "Book title"},
+        "price": {"sum": "12.0"},
+        "created_date": "2021-05-13Z",
+        "fund_distribution": [{"fund_code": {"value": "ABC"}}],
+        "note": [{"note_text": "CC-abc"}],
+    }
+    return po_line_record_all
+
+
+@pytest.fixture()
+def po_line_record_missing_fields():
+    """A PO line record without non-required fields."""
+    po_line_record_missing_fields = {
+        "vendor_account": "Corporation",
+        "number": "POL-123",
+        "resource_metadata": {"title": None},
+        "price": {"sum": "0.0"},
+        "created_date": "2021-05-13Z",
+        "fund_distribution": [{"fund_code": {"value": ""}}],
+        "note": [],
+    }
+    return po_line_record_missing_fields
+
+
+@pytest.fixture()
+def po_line_record_multiple_funds():
+    """A PO line record with multiple funds."""
+    po_line_record_multiple_funds = {
+        "vendor_account": "Corporation",
+        "number": "POL-123",
+        "resource_metadata": {"title": "Book title"},
+        "price": {"sum": "12.0"},
+        "created_date": "2021-05-13Z",
+        "fund_distribution": [
+            {"fund_code": {"value": "ABC"}},
+            {"fund_code": {"value": "DEF"}},
+        ],
+        "note": [{"note_text": ""}],
+    }
+    return po_line_record_multiple_funds
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,9 @@ def test_cc_slips_date_provided(mocked_alma, mocked_alma_env_vars, runner):
             "--source_email",
             "noreply@example.com",
             "--recipient_email",
-            "test@example.com",
+            "test1@example.com",
+            "--recipient_email",
+            "test2@example.com",
         ],
     )
     assert result.exit_code == 0
@@ -37,7 +39,9 @@ def test_cc_slips_no_date_provided(mocked_alma, mocked_alma_env_vars, runner):
             "--source_email",
             "noreply@example.com",
             "--recipient_email",
-            "test@example.com",
+            "test1@example.com",
+            "--recipient_email",
+            "test2@example.com",
         ],
     )
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,47 @@
+import boto3
 from freezegun import freeze_time
+from moto import mock_ses
 
 from llama.cli import cli
+
+
+@mock_ses
+def test_cc_slips_date_provided(mocked_alma, mocked_alma_env_vars, runner):
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    result = runner.invoke(
+        cli,
+        [
+            "cc-slips",
+            "--date",
+            "2021-05-13",
+            "--source_email",
+            "noreply@example.com",
+            "--recipient_email",
+            "test@example.com",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.output.startswith("Email sent! Message ID:")
+
+
+@mock_ses
+@freeze_time("2021-05-14")
+def test_cc_slips_no_date_provided(mocked_alma, mocked_alma_env_vars, runner):
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    result = runner.invoke(
+        cli,
+        [
+            "cc-slips",
+            "--source_email",
+            "noreply@example.com",
+            "--recipient_email",
+            "test@example.com",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.output.startswith("Email sent! Message ID:")
 
 
 def test_concat_timdex_export_all_options_provided_success(mocked_s3, runner, s3):

--- a/tests/test_credit_card_slips.py
+++ b/tests/test_credit_card_slips.py
@@ -1,0 +1,132 @@
+import boto3
+from defusedxml import ElementTree as ET
+from moto import mock_ses
+
+from llama import credit_card_slips
+
+
+def test_create_credit_card_slips(mocked_alma, mocked_alma_env_vars, alma_json_headers):
+    credit_card_slips_xml_string = credit_card_slips.create_credit_card_slips(
+        "2021-05-13"
+    )
+    credit_card_slips_xml = ET.fromstring(credit_card_slips_xml_string)
+    assert credit_card_slips_xml.find('.//td[@class="poline"]').text == "POL-123"
+
+
+def test_create_dict_from_po_line_record_all_fields(
+    mocked_alma,
+    mocked_alma_env_vars,
+    alma_json_headers,
+    po_line_record_all_fields,
+):
+    value_dict = credit_card_slips.create_dict_from_po_line_record(
+        po_line_record_all_fields, alma_json_headers
+    )
+    assert value_dict["account_1"] == "456"
+    assert "account_2" not in value_dict
+    assert value_dict["cardholder"] == "abc"
+    assert value_dict["invoice_num"] == "Invoice #: 210513BOO"
+    assert value_dict["item_title"] == "Book title"
+    assert value_dict["poline"] == "POL-123"
+    assert value_dict["price"] == "$12.00"
+    assert value_dict["vendor"] == "Corporation"
+
+
+def test_create_dict_from_po_line_record_missing_fields(
+    mocked_alma,
+    mocked_alma_env_vars,
+    alma_json_headers,
+    po_line_record_missing_fields,
+):
+    value_dict_missing_fields = credit_card_slips.create_dict_from_po_line_record(
+        po_line_record_missing_fields, alma_json_headers
+    )
+    assert value_dict_missing_fields["item_title"] == "Unknown title"
+    assert value_dict_missing_fields["price"] == "$0.00"
+    assert value_dict_missing_fields["invoice_num"] == "Invoice #: 210513UNK"
+    assert value_dict_missing_fields["cardholder"] == "No cardholder note"
+
+
+def test_create_dict_from_po_line_record_multiple_funds(
+    mocked_alma,
+    mocked_alma_env_vars,
+    alma_json_headers,
+    po_line_record_multiple_funds,
+):
+    value_dict_multiple_funds = credit_card_slips.create_dict_from_po_line_record(
+        po_line_record_multiple_funds, alma_json_headers
+    )
+    assert value_dict_multiple_funds["account_2"] == "789"
+
+
+def test_get_account_from_fund_code_with_fund_code(
+    mocked_alma,
+    mocked_alma_env_vars,
+    alma_json_headers,
+):
+    account = credit_card_slips.get_account_from_fund_code("ABC", alma_json_headers)
+    assert account == "456"
+
+
+def test_get_account_from_fund_code_without_fund_code(
+    alma_json_headers,
+):
+    account = credit_card_slips.get_account_from_fund_code("", alma_json_headers)
+    assert account == "No fund code"
+
+
+def test_get_cardholder_from_notes_with_cardholder_note(po_line_record_all_fields):
+    cardholder = credit_card_slips.get_cardholder_from_notes(po_line_record_all_fields)
+    assert cardholder == "abc"
+
+
+def test_get_cardholder_from_notes_without_cardholder_note(
+    po_line_record_missing_fields,
+):
+    cardholder = credit_card_slips.get_cardholder_from_notes(
+        po_line_record_missing_fields
+    )
+    assert cardholder == "No cardholder note"
+
+
+def test_get_po_title_with_title():
+    po_rec_1 = {"resource_metadata": {"title": "Book title"}}
+    assert credit_card_slips.get_po_title(po_rec_1) == "Book title"
+
+
+def test_get_po_title_without_title():
+    po_rec_2 = {"resource_metadata": {"title": None}}
+    assert credit_card_slips.get_po_title(po_rec_2) == "Unknown title"
+
+
+def test_load_xml_template():
+    root = credit_card_slips.load_xml_template("config/credit_card_slip_template.xml")
+    element_classes = [
+        "vendor",
+        "poline",
+        "item_title",
+        "price",
+        "po_date",
+        "invoice_num",
+        "credit_memo_num",
+        "account_1",
+        "account_2",
+        "cardholder",
+    ]
+    assert root.tag == "ccslip"
+    for element_class in element_classes:
+        assert root.find(f'.//td[@class="{element_class}"]') is not None
+
+
+@mock_ses
+def test_send_credit_card_slips_email():
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    response = credit_card_slips.send_credit_card_slips_email(
+        ses_client,
+        "2021-08-09",
+        "<html/>",
+        "noreply@example.com",
+        "test@example.com",
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/test_credit_card_slips.py
+++ b/tests/test_credit_card_slips.py
@@ -127,6 +127,6 @@ def test_send_credit_card_slips_email():
         "2021-08-09",
         "<html/>",
         "noreply@example.com",
-        "test@example.com",
+        ["test@example.com"],
     )
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/test_credit_card_slips.py
+++ b/tests/test_credit_card_slips.py
@@ -1,6 +1,4 @@
-import boto3
 from defusedxml import ElementTree as ET
-from moto import mock_ses
 
 from llama import credit_card_slips
 
@@ -116,17 +114,3 @@ def test_load_xml_template():
     assert root.tag == "ccslip"
     for element_class in element_classes:
         assert root.find(f'.//td[@class="{element_class}"]') is not None
-
-
-@mock_ses
-def test_send_credit_card_slips_email():
-    ses_client = boto3.client("ses", region_name="us-east-1")
-    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
-    response = credit_card_slips.send_credit_card_slips_email(
-        ses_client,
-        "2021-08-09",
-        "<html/>",
-        "noreply@example.com",
-        ["test@example.com"],
-    )
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,0 +1,18 @@
+import boto3
+from moto import mock_ses
+
+from llama import ses
+
+
+@mock_ses
+def test_send_credit_card_slips_email():
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    response = ses.SES().send_email(
+        "Email subject",
+        "<html/>",
+        "attachment",
+        "noreply@example.com",
+        ["test@example.com"],
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200


### PR DESCRIPTION
#### What does this PR do?
* Add CLI command to send credit card slips email
* Add functions to creat credit card slips and send the slips as an email attachment
* Add corresponding tests for CLI command and functions
* Switch to defusedxml to fix potential security issues
* Add XML template for credit card slips

#### Helpful background context
This will be run daily and sent to a Tech Services moira list. @zotoMIT We can discuss the best method for automating this.

#### How can a reviewer manually see the effects of these changes?
Run tests with `pipenv run pytest`. With an `API_KEY` env var set with an Alma API key with the appropriate Acquisitions read permissions on our production instance, you can send the credit slips email to yourself with `pipenv run llama cc-slips --source_email noreply@libraries.mit.edu --recipient_email YOUR@EMAIL.ADDRESS`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/INFRA-163

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
