### PR TITLE
Create automated daily email of credit card slips to Tech Services staff

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ requests = "*"
 lxml = "*"
 boto3 = "*"
 s3-concat = "*"
+defusedxml = "*"
 
 [dev-packages]
 black = "==21.7b0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "567508defe7e0ce592e1b44bbe60af2631146b00864425e275de31f97bbd445a"
+            "sha256": "ff55d9b100a6e1565924979cd7ae9e459c55ebad980a191423439850da5432b0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:48241d2ca6074dd35411e1e72a4ca8ae5043e8e4aba0a9975a94af66382995da",
-                "sha256:dc44be94fa03245fd0cfff8a3fcc17d79283cfda9a39ae2e5cdedcd75749e089"
+                "sha256:5e5f60ece9b73d48f668bef56ddcde716f013b48a62fdf9c5eac9512a5981136",
+                "sha256:69a5ebbd5fda6742d20fd536cd9b2927f2eaa8dde84ad529fe816231afcf9c68"
             ],
             "index": "pypi",
-            "version": "==1.18.15"
+            "version": "==1.18.17"
         },
         "botocore": {
             "hashes": [
-                "sha256:5f9686f42fcc6df0eb3ca5804113135f06ae92a6010347665ca7670f1397bff1",
-                "sha256:90b50e321278223c794032ae1ded7dfebdc73c54cc3cbbf72648e4cfdf060529"
+                "sha256:5b665142bdb2c30fc86b15bc48dd8b74c9cac69dc3e20b6d8f79cb60ff368797",
+                "sha256:a0d64369857d86b3a6d01b0c5933671c2394584311ce3af702271ba221b09afa"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.15"
+            "version": "==1.21.17"
         },
         "certifi": {
             "hashes": [
@@ -46,6 +46,14 @@
             ],
             "markers": "python_version >= '3'",
             "version": "==2.0.4"
+        },
+        "defusedxml": {
+            "hashes": [
+                "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69",
+                "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            ],
+            "index": "pypi",
+            "version": "==0.7.1"
         },
         "idna": {
             "hashes": [
@@ -197,19 +205,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:48241d2ca6074dd35411e1e72a4ca8ae5043e8e4aba0a9975a94af66382995da",
-                "sha256:dc44be94fa03245fd0cfff8a3fcc17d79283cfda9a39ae2e5cdedcd75749e089"
+                "sha256:5e5f60ece9b73d48f668bef56ddcde716f013b48a62fdf9c5eac9512a5981136",
+                "sha256:69a5ebbd5fda6742d20fd536cd9b2927f2eaa8dde84ad529fe816231afcf9c68"
             ],
             "index": "pypi",
-            "version": "==1.18.15"
+            "version": "==1.18.17"
         },
         "botocore": {
             "hashes": [
-                "sha256:5f9686f42fcc6df0eb3ca5804113135f06ae92a6010347665ca7670f1397bff1",
-                "sha256:90b50e321278223c794032ae1ded7dfebdc73c54cc3cbbf72648e4cfdf060529"
+                "sha256:5b665142bdb2c30fc86b15bc48dd8b74c9cac69dc3e20b6d8f79cb60ff368797",
+                "sha256:a0d64369857d86b3a6d01b0c5933671c2394584311ce3af702271ba221b09afa"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.15"
+            "version": "==1.21.17"
         },
         "certifi": {
             "hashes": [
@@ -339,7 +347,7 @@
                 "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
                 "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==5.5"
         },
         "coveralls": {
@@ -361,6 +369,8 @@
                 "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1",
                 "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177",
                 "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250",
+                "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586",
+                "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3",
                 "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca",
                 "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d",
                 "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"
@@ -413,6 +423,14 @@
             ],
             "markers": "python_version >= '3'",
             "version": "==3.2"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:0645585859e9a6689c523927a5032f2ba5919f1f7d0e84bd4533312320de1ff9",
+                "sha256:51c6635429c77cf1ae634c997ff9e53ca3438b495f10a55ba28594dd69764a8b"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.6.3"
         },
         "iniconfig": {
             "hashes": [
@@ -505,11 +523,11 @@
                 "s3"
             ],
             "hashes": [
-                "sha256:4ea538fe090b964c22bb98a6f87d3c589eaf754893d297d58b74dedb94d4448c",
-                "sha256:ab9f7114bf5b60e9d3ae518c0694bf53e111a5c0c195b19e89707c97ab71b53c"
+                "sha256:210634dac5943dfa0db59107d1b10be9897ae37b55682f5c3808a0e0b289321f",
+                "sha256:b0b5a9179bcb4833fd2f67e31e44004d7ec7687106ab22150cbeac7e6e97b725"
             ],
             "index": "pypi",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         },
         "mypy-extensions": {
             "hashes": [
@@ -726,11 +744,11 @@
         },
         "responses": {
             "hashes": [
-                "sha256:18a5b88eb24143adbf2b4100f328a2f5bfa72fbdacf12d97d41f07c26c45553d",
-                "sha256:b54067596f331786f5ed094ff21e8d79e6a1c68ef625180a7d34808d6f36c11b"
+                "sha256:9476775d856d3c24ae660bbebe29fb6d789d4ad16acd723efbfb6ee20990b899",
+                "sha256:d8d0f655710c46fd3513b9202a7f0dcedd02ca0f8cf4976f27fa8ab5b81e656d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.13.3"
+            "version": "==0.13.4"
         },
         "s3transfer": {
             "hashes": [
@@ -809,6 +827,14 @@
                 "sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"
             ],
             "version": "==0.12.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3",
+                "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.5.0"
         }
     }
 }

--- a/config/credit_card_slip_template.xml
+++ b/config/credit_card_slip_template.xml
@@ -1,0 +1,130 @@
+<ccslip>
+    <p align="center">
+      <b>MIT Libraries Credit Card Purchase</b><br/>
+      Monograph Acquisitions, Rm. NE36-6101</p>
+    <br/>
+    <br/>
+    <table border="0" width="100%" align="left">
+      <tr>
+        <td colspan="2">
+          <u>CHARGE INFORMATION</u>
+        </td>
+      </tr>
+      <tr>
+        <td align="left">Date:</td>
+        <td class="po_date" align="left">20210518</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="left">Cardholder:</td>
+        <td class="cardholder" align="left"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="left">Vendor code:
+        </td>
+        <td class="vendor" align="left"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="left">Account 1:
+        </td>
+        <td class="account_1" align="left"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="left">Account 2:
+        </td>
+        <td class="account_2" align="left"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><br/></td>
+      </tr>
+      <tr>
+        <td>PO Line #:</td>
+        <td>TITLE:</td>
+        <td>PRICE</td>
+      </tr>
+      <tr>
+        <td class="poline"></td>
+        <td class="item_title"></td>
+        <td class="price"></td>
+      </tr>
+      <tr>
+        <td><br/></td>
+      </tr>
+      <tr>
+        <td></td>
+        <td align="right">Transaction fee:
+        </td>
+        <td>__________</td>
+      </tr>
+      <tr>
+        <td></td>
+        <td align="right">TOTAL DUE:
+        </td>
+        <td class="price"></td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <u>SAP INFORMATION</u>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">SAP document #:</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">Date posted in SAP:</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">Verified by:</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">Verified date:</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><br/></td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <u>ALMA INVOICE INFORMATION</u>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td class="invoice_num" colspan="2"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td style="padding-left:30px;" colspan="3">Inv #: Date charged + 1st 3 letters of title: YYMMDD "xxx")</td>
+      </tr>
+      <tr>
+        <td style="padding-left:30px;" class="credit_memo_num" colspan="3">For Credit Memo #, use Invoice # + CRE (YYMMDD"XXX"CRE)</td>
+      </tr>
+      <tr>
+        <td colspan="2">Use Charge Date above for Invoice Date.</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><br/></td>
+      </tr>
+      <tr>
+        <td colspan="2">Date entered in Alma:
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td colspan="2">Entered by:
+        </td>
+        <td></td>
+      </tr>
+    </table>
+    <hr class="pb"/>
+    <p style="page-break-before: always" />
+</ccslip>

--- a/cron.d/credit-card-slips
+++ b/cron.d/credit-card-slips
@@ -1,0 +1,7 @@
+# Cron jobs for credit card slips
+#
+# Daily at 0801
+01 08 * * * gituser /mnt/alma/alma-scripts/scripts/Credit-Card-Slips.sh
+#
+#make sure to keep required newline at end of file -
+

--- a/llama/alma.py
+++ b/llama/alma.py
@@ -1,0 +1,53 @@
+import os
+
+import requests
+
+
+class Alma_API_Client:
+    """An Alma_API_Client class that provides a client for interacting with the Alma API
+    and specific functionality necessary for llama scripts."""
+
+    def __init__(self):
+        self.api_key = os.environ["API_KEY"]
+        self.api_url = os.environ["API_URL"]
+
+    def create_api_headers(self, accept, content_type):
+        """Create API headers for requesting content from the Alma API."""
+        api_headers = {
+            "accept": accept,
+            "content-type": content_type,
+            "Authorization": f"apikey {self.api_key}",
+        }
+        self.api_headers = api_headers
+
+    def get_brief_po_lines(self, acquisition_method=""):
+        """Get brief PO lines with an option to narrow by acquisition_method. The
+        PO line records retrieved from this endpoint do not contain all of the PO line
+        data and users may wish to retrieve the full PO line record with the
+        get_full_po_line method."""
+        po_line_payload = {
+            "status": "ACTIVE",
+            "limit": "100",
+            "offset": 0,
+            "acquisition_method": acquisition_method,
+        }
+        brief_po_lines = ""
+        while brief_po_lines != []:
+            response = requests.get(
+                f"{self.api_url}acq/po-lines",
+                params=po_line_payload,
+                headers=self.api_headers,
+            )
+            response = response.json()
+            brief_po_lines = response.get("po_line", [])
+            for brief_po_line in brief_po_lines:
+                yield brief_po_line
+            po_line_payload["offset"] += 100
+
+    def get_full_po_line(self, po_line_id):
+        """Get a full PO line record using the PO line ID."""
+        full_po_line = requests.get(
+            f"{self.api_url}acq/po-lines/{po_line_id}",
+            headers=self.api_headers,
+        ).json()
+        return full_po_line

--- a/llama/cli.py
+++ b/llama/cli.py
@@ -1,15 +1,69 @@
-from datetime import datetime
+import datetime
 
 import click
+from botocore.exceptions import ClientError
 
+from llama import credit_card_slips
+from llama.alma import Alma_API_Client
 from llama.s3 import S3
+from llama.ses import SES
 
 
 @click.group()
 @click.pass_context
 def cli(ctx):
     ctx.ensure_object(dict)
-    ctx.obj["today"] = datetime.today()
+    ctx.obj["today"] = datetime.datetime.today()
+
+
+@cli.command()
+@click.option(
+    "--date",
+    help=(
+        "Optional date of exports to process, in 'YYYY-MM-DD' format. Defaults to "
+        "yesterday's date if not provided."
+    ),
+)
+@click.option(
+    "--source_email",
+    required=True,
+    help="The email address sending the credit card slips.",
+)
+@click.option(
+    "--recipient_email",
+    required=True,
+    multiple=True,
+    help="The email address receiving the credit card slips. Repeatable",
+)
+@click.pass_context
+def cc_slips(ctx, date, source_email, recipient_email):
+    if date is None:
+        date = (ctx.obj["today"] - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+    alma_api_client = Alma_API_Client()
+    alma_api_client.create_api_headers("application/json", "application/json")
+    credit_card_full_po_lines = (
+        credit_card_slips.get_credit_card_full_po_lines_from_date(alma_api_client, date)
+    )
+    po_line_dicts = credit_card_slips.create_po_line_dicts(
+        alma_api_client, credit_card_full_po_lines
+    )
+    credit_card_slip_xml_data = credit_card_slips.xml_data_from_dicts(po_line_dicts)
+    ses_client = SES()
+    message = ses_client.create_email(
+        f"Credit card slips {date}",
+        credit_card_slip_xml_data,
+        f"{date}_credit_card_slips.htm",
+    )
+    try:
+        response = ses_client.send_email(
+            source_email,
+            list(recipient_email),
+            message,
+        )
+    except ClientError as e:
+        click.echo(e.response["Error"]["Message"])
+    else:
+        click.echo(f'Email sent! Message ID: {response["MessageId"]}')
 
 
 @cli.command()

--- a/llama/credit_card_slips.py
+++ b/llama/credit_card_slips.py
@@ -1,0 +1,120 @@
+import requests
+from defusedxml import ElementTree as ET
+
+
+def create_po_line_dict(alma_api_client, po_line_record):
+    """Create dict of the required data for credit card slips from a PO line record. The
+    keys of the dict map to the appropriate element classes in the XML template."""
+    po_line_dict = {}
+    po_line_dict["vendor"] = po_line_record["vendor_account"]
+    po_line_dict["poline"] = po_line_record["number"]
+
+    title = get_po_title(po_line_record)
+    po_line_dict["item_title"] = title
+
+    price = format(float(po_line_record["price"]["sum"]), ".2f")
+    po_line_dict["price"] = f"${price}"
+
+    # Stakeholder requested format of date
+    po_line_created_date = "".join(
+        filter(str.isdigit, po_line_record["created_date"][2:])
+    )
+    po_line_dict["po_date"] = po_line_created_date
+    po_line_dict[
+        "invoice_num"
+    ] = f"Invoice #: {po_line_created_date}{title[:3].upper()}"
+
+    fund_code_1 = po_line_record["fund_distribution"][0]["fund_code"]["value"]
+    po_line_dict["account_1"] = get_account_from_fund_code(alma_api_client, fund_code_1)
+    if len(po_line_record["fund_distribution"]) > 1:
+        fund_code_2 = po_line_record["fund_distribution"][1]["fund_code"]["value"]
+        po_line_dict["account_2"] = get_account_from_fund_code(
+            alma_api_client, fund_code_2
+        )
+    po_line_dict["cardholder"] = get_cardholder_from_notes(po_line_record)
+    return po_line_dict
+
+
+def create_po_line_dicts(alma_api_client, full_po_line_records):
+    """Create PO line dicts from a set of full PO line records and return a generator for
+    easier use by other functions."""
+    for full_po_line_record in full_po_line_records:
+        po_line_dict = create_po_line_dict(
+            alma_api_client,
+            full_po_line_record,
+        )
+        yield po_line_dict
+
+
+def get_account_from_fund_code(client, fund_code):
+    """Get account number based on a fund code."""
+    if fund_code == "":
+        account = "No fund code"
+    else:
+        fund_payload = {"q": f"fund_code~{fund_code}"}
+        response = requests.get(
+            f"{client.api_url}acq/funds",
+            params=fund_payload,
+            headers=client.api_headers,
+        ).json()
+        account = response["fund"][0]["external_id"]
+    return account
+
+
+def get_cardholder_from_notes(po_line_record):
+    """Get cardholder note that begins with a CC- prefix from a PO line record."""
+    cardholder = "No cardholder note"
+    for note in [
+        n
+        for n in po_line_record["note"]
+        if "note" in po_line_record and n["note_text"].startswith("CC-")
+    ]:
+        cardholder = note["note_text"][3:]
+    return cardholder
+
+
+def get_credit_card_full_po_lines_from_date(alma_api_client, date):
+    """Get full PO line records for credit card purchases (acquisition_methood =
+    EXCHANGEE) from the specified date and return a generator for easier use by other
+    functions."""
+    brief_po_lines = alma_api_client.get_brief_po_lines("EXCHANGE")
+    for brief_po_line in (p for p in brief_po_lines if p["created_date"] == f"{date}Z"):
+        full_po_line = alma_api_client.get_full_po_line(brief_po_line["number"])
+        yield full_po_line
+
+
+def get_po_title(po_line_record):
+    """Retrieve title from PO line record. PO line records store the title as a null
+    value if no item is attached but a string is required for generating the invoice
+    number."""
+    title = po_line_record["resource_metadata"]["title"]
+    title = "Unknown title" if title is None else title
+    return title
+
+
+def load_xml_template(xml_file):
+    """Create Elementree object using XML template."""
+    tree = ET.parse(xml_file)
+    xml_template = tree.getroot()
+    return xml_template
+
+
+def populate_credit_card_slip(xml_template, po_line_dict):
+    """Populate XML template with credit card slip data using a PO line dict with keys
+    that correspond to the element classes in the XML template."""
+    for k, v in po_line_dict.items():
+        for element in xml_template.findall(f'.//td[@class="{k}"]'):
+            element.text = v
+    return xml_template
+
+
+def xml_data_from_dicts(po_line_dicts):
+    """Create credit card slips XML data from a set of PO line dicts."""
+    xml_root = ET.fromstring("<html></html>")
+    for po_line_dict in po_line_dicts:
+        xml_template = load_xml_template("config/credit_card_slip_template.xml")
+        xml_root.append(populate_credit_card_slip(xml_template, po_line_dict))
+        credit_card_slips_xml_data = ET.tostring(
+            xml_root, encoding="unicode", method="xml"
+        )
+    return credit_card_slips_xml_data

--- a/llama/ses.py
+++ b/llama/ses.py
@@ -1,0 +1,39 @@
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+
+from boto3 import client
+
+
+class SES:
+    """An SES class that provides a generic boto3 SES client with specific SES
+    functionality necessary for llama scripts"""
+
+    def __init__(self):
+        self.client = client("ses", region_name="us-east-1")
+
+    def create_email(
+        self,
+        subject,
+        attachment_content,
+        attachment_name,
+    ):
+        """Create an email."""
+        message = MIMEMultipart()
+        message["Subject"] = subject
+        attachment_object = MIMEApplication(attachment_content)
+        attachment_object.add_header(
+            "Content-Disposition", "attachment", filename=attachment_name
+        )
+        message.attach(attachment_object)
+        return message
+
+    def send_email(self, source_email, recipients, message):
+        """Send email via SES. Recipients parameter must be a list and not a str."""
+        response = self.client.send_raw_email(
+            Source=source_email,
+            Destinations=recipients,
+            RawMessage={
+                "Data": message.as_string(),
+            },
+        )
+        return response

--- a/scripts/Credit-Card-Slips.sh
+++ b/scripts/Credit-Card-Slips.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#source the environment variables here so that the script runs correctly for the cron user
+# Replace with new method for acquiring API_URL and API_KEY variables
+
+#make the logs dir if it doesn't already exist
+mkdir /mnt/alma/logs
+
+#change to the alma-scripts directory
+cd /mnt/alma/alma-scripts
+
+#install the dependencies and dev tools for them
+/usr/bin/python3.8 -m pipenv --python 3.8 install --dev
+
+#run the update, which automatically only uses the current days files 
+/usr/bin/python3.8 -m pipenv run llama cc-slips --source_email noreply@libraries.mit.edu --recipient_email ils-lib@mit.edu --recipient_email monoacq@mit.edu > /mnt/alma/logs/credit-card-slips.log 2>&1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,18 @@
 import os
+from unittest import mock
 
 import boto3
 import pytest
+import requests_mock
 from click.testing import CliRunner
 from moto import mock_s3
 
+from llama.alma import Alma_API_Client
 from llama.s3 import S3
 
 
 @pytest.fixture(scope="function")
 def aws_credentials():
-    """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
@@ -19,9 +21,49 @@ def aws_credentials():
 
 @pytest.fixture(scope="function")
 def bucket_env():
-    """Mocked AWS Credentials for moto."""
     os.environ["ALMA_BUCKET"] = "ils-sftp"
     os.environ["DIP_ALEPH_BUCKET"] = "dip-ils-bucket"
+
+
+@pytest.fixture()
+def mocked_alma(po_line_record_all_fields):
+    with requests_mock.Mocker() as m:
+        fund_code_record_abc = {"fund": [{"external_id": "456"}]}
+        fund_code_record_def = {"fund": [{"external_id": "789"}]}
+        po_lines = {
+            "po_line": [
+                {"number": "POL-123", "created_date": "2021-05-13Z"},
+                {"number": "POL-456", "created_date": "2021-05-02Z"},
+            ]
+        }
+        m.get("http://example.com/acq/funds?q=fund_code~ABC", json=fund_code_record_abc)
+        m.get("http://example.com/acq/funds?q=fund_code~DEF", json=fund_code_record_def)
+        m.get(
+            "http://example.com/acq/po-lines?status=ACTIVE&limit=100&offset=0",
+            json=po_lines,
+        )
+        m.get(
+            "http://example.com/acq/po-lines?status=ACTIVE&limit=100&offset=100",
+            json={},
+        )
+        m.get("http://example.com/acq/po-lines/POL-123", json=po_line_record_all_fields)
+        m.get("http://example.com/acq/po-lines/POL-456", json=po_line_record_wrong_date)
+        yield m
+
+
+@pytest.fixture()
+def mocked_alma_api_client(mocked_alma_env_vars):
+    alma_api_client = Alma_API_Client()
+    alma_api_client.create_api_headers("application/json", "application/json")
+    return alma_api_client
+
+
+@pytest.fixture()
+def mocked_alma_env_vars():
+    with mock.patch.dict(
+        os.environ, {"API_URL": "http://example.com/", "API_KEY": "abc123"}
+    ):
+        yield
 
 
 @pytest.fixture(scope="function")
@@ -51,6 +93,68 @@ def mocked_s3(aws_credentials):
         )
         s3.create_bucket(Bucket="dip-ils-bucket")
         yield s3
+
+
+@pytest.fixture()
+def po_line_record_all_fields():
+    po_line_record_all = {
+        "acquisition_method": {"desc": "Credit Card"},
+        "vendor_account": "Corporation",
+        "number": "POL-123",
+        "resource_metadata": {"title": "Book title"},
+        "price": {"sum": "12.0"},
+        "created_date": "2021-05-13Z",
+        "fund_distribution": [{"fund_code": {"value": "ABC"}}],
+        "note": [{"note_text": "CC-abc"}],
+    }
+    return po_line_record_all
+
+
+@pytest.fixture()
+def po_line_record_missing_fields():
+    po_line_record_missing_fields = {
+        "vendor_account": "Corporation",
+        "number": "POL-123",
+        "resource_metadata": {"title": None},
+        "price": {"sum": "0.0"},
+        "created_date": "2021-05-13Z",
+        "fund_distribution": [{"fund_code": {"value": ""}}],
+        "note": [],
+    }
+    return po_line_record_missing_fields
+
+
+@pytest.fixture()
+def po_line_record_multiple_funds():
+    po_line_record_multiple_funds = {
+        "vendor_account": "Corporation",
+        "number": "POL-123",
+        "resource_metadata": {"title": "Book title"},
+        "price": {"sum": "12.0"},
+        "created_date": "2021-05-13Z",
+        "fund_distribution": [
+            {"fund_code": {"value": "ABC"}},
+            {"fund_code": {"value": "DEF"}},
+        ],
+        "note": [{"note_text": ""}],
+    }
+    return po_line_record_multiple_funds
+
+
+@pytest.fixture()
+def po_line_record_wrong_date():
+    """A PO line record with the wrong date that should be filtered out."""
+    po_line_record_all = {
+        "acquisition_method": {"desc": "Credit Card"},
+        "vendor_account": "Another corporation",
+        "number": "POL-457",
+        "resource_metadata": {"title": "DVD title"},
+        "price": {"sum": "24.0"},
+        "created_date": "2021-05-02Z",
+        "fund_distribution": [{"fund_code": {"value": "DEF"}}],
+        "note": [{"note_text": "CC-jkl"}],
+    }
+    return po_line_record_all
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -1,0 +1,24 @@
+from llama.alma import Alma_API_Client
+
+
+def test_alma_create_api_headers(mocked_alma_env_vars):
+    alma_api_client = Alma_API_Client()
+    assert hasattr(alma_api_client, "api_headers") is False
+    alma_api_client.create_api_headers("application/json", "application/json")
+    assert alma_api_client.api_headers == {
+        "Authorization": "apikey abc123",
+        "accept": "application/json",
+        "content-type": "application/json",
+    }
+
+
+def test_alma_get_brief_po_lines(mocked_alma, mocked_alma_api_client):
+    po_line_stubs = mocked_alma_api_client.get_brief_po_lines()
+    assert next(po_line_stubs) == {"created_date": "2021-05-13Z", "number": "POL-123"}
+    assert next(po_line_stubs) == {"created_date": "2021-05-02Z", "number": "POL-456"}
+
+
+def test_alma_get_po_line_full_record(mocked_alma, mocked_alma_api_client):
+    po_line_record = mocked_alma_api_client.get_full_po_line("POL-123")
+    assert po_line_record["resource_metadata"]["title"] == "Book title"
+    assert po_line_record["created_date"] == "2021-05-13Z"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,51 @@
+import boto3
 from freezegun import freeze_time
+from moto import mock_ses
 
 from llama.cli import cli
+
+
+@mock_ses
+def test_cc_slips_date_provided(mocked_alma, mocked_alma_env_vars, runner):
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    result = runner.invoke(
+        cli,
+        [
+            "cc-slips",
+            "--date",
+            "2021-05-13",
+            "--source_email",
+            "noreply@example.com",
+            "--recipient_email",
+            "test1@example.com",
+            "--recipient_email",
+            "test2@example.com",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.output.startswith("Email sent! Message ID:")
+
+
+@mock_ses
+@freeze_time("2021-05-14")
+def test_cc_slips_no_date_provided(mocked_alma, mocked_alma_env_vars, runner):
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    result = runner.invoke(
+        cli,
+        [
+            "cc-slips",
+            "--source_email",
+            "noreply@example.com",
+            "--recipient_email",
+            "test1@example.com",
+            "--recipient_email",
+            "test2@example.com",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.output.startswith("Email sent! Message ID:")
 
 
 def test_concat_timdex_export_all_options_provided_success(mocked_s3, runner, s3):

--- a/tests/test_credit_card_slips.py
+++ b/tests/test_credit_card_slips.py
@@ -1,0 +1,161 @@
+from defusedxml import ElementTree as ET
+
+from llama import credit_card_slips
+
+
+def test_create_po_line_dict_all_fields(
+    mocked_alma,
+    mocked_alma_api_client,
+    mocked_alma_env_vars,
+    po_line_record_all_fields,
+):
+    po_line_dict = credit_card_slips.create_po_line_dict(
+        mocked_alma_api_client,
+        po_line_record_all_fields,
+    )
+    assert po_line_dict["account_1"] == "456"
+    assert "account_2" not in po_line_dict
+    assert po_line_dict["cardholder"] == "abc"
+    assert po_line_dict["invoice_num"] == "Invoice #: 210513BOO"
+    assert po_line_dict["item_title"] == "Book title"
+    assert po_line_dict["poline"] == "POL-123"
+    assert po_line_dict["price"] == "$12.00"
+    assert po_line_dict["vendor"] == "Corporation"
+
+
+def test_create_po_line_dict_missing_fields(
+    mocked_alma,
+    mocked_alma_api_client,
+    mocked_alma_env_vars,
+    po_line_record_missing_fields,
+):
+    po_line_dict_missing_fields = credit_card_slips.create_po_line_dict(
+        mocked_alma_api_client,
+        po_line_record_missing_fields,
+    )
+    assert po_line_dict_missing_fields["item_title"] == "Unknown title"
+    assert po_line_dict_missing_fields["price"] == "$0.00"
+    assert po_line_dict_missing_fields["invoice_num"] == "Invoice #: 210513UNK"
+    assert po_line_dict_missing_fields["cardholder"] == "No cardholder note"
+
+
+def test_create_po_line_dict_multiple_funds(
+    mocked_alma,
+    mocked_alma_api_client,
+    mocked_alma_env_vars,
+    po_line_record_multiple_funds,
+):
+    po_line_dict_multiple_funds = credit_card_slips.create_po_line_dict(
+        mocked_alma_api_client,
+        po_line_record_multiple_funds,
+    )
+    assert po_line_dict_multiple_funds["account_2"] == "789"
+
+
+def test_create_po_line_dicts(
+    mocked_alma, mocked_alma_api_client, po_line_record_all_fields
+):
+    po_line_records = [po_line_record_all_fields]
+    po_line_dicts = credit_card_slips.create_po_line_dicts(
+        mocked_alma_api_client, po_line_records
+    )
+    for po_line_dict in po_line_dicts:
+        assert po_line_dict["account_1"] == "456"
+        assert "account_2" not in po_line_dict
+        assert po_line_dict["cardholder"] == "abc"
+        assert po_line_dict["invoice_num"] == "Invoice #: 210513BOO"
+        assert po_line_dict["item_title"] == "Book title"
+        assert po_line_dict["poline"] == "POL-123"
+        assert po_line_dict["price"] == "$12.00"
+        assert po_line_dict["vendor"] == "Corporation"
+
+
+def test_get_account_from_fund_code_with_fund_code(
+    mocked_alma,
+    mocked_alma_api_client,
+    mocked_alma_env_vars,
+):
+    account = credit_card_slips.get_account_from_fund_code(
+        mocked_alma_api_client, "ABC"
+    )
+    assert account == "456"
+
+
+def test_get_account_from_fund_code_without_fund_code(
+    mocked_alma_api_client, mocked_alma_env_vars
+):
+    account = credit_card_slips.get_account_from_fund_code(mocked_alma_api_client, "")
+    assert account == "No fund code"
+
+
+def test_get_cardholder_from_notes_with_cardholder_note(
+    po_line_record_all_fields, mocked_alma_env_vars
+):
+    cardholder = credit_card_slips.get_cardholder_from_notes(po_line_record_all_fields)
+    assert cardholder == "abc"
+
+
+def test_get_cardholder_from_notes_without_cardholder_note(
+    po_line_record_missing_fields,
+):
+    cardholder = credit_card_slips.get_cardholder_from_notes(
+        po_line_record_missing_fields
+    )
+    assert cardholder == "No cardholder note"
+
+
+def test_get_credit_card_full_po_lines_from_date(mocked_alma, mocked_alma_api_client):
+    po_line_records = credit_card_slips.get_credit_card_full_po_lines_from_date(
+        mocked_alma_api_client, "2021-05-13"
+    )
+    for po_line_record in po_line_records:
+        assert po_line_record["resource_metadata"]["title"] == "Book title"
+        assert po_line_record["created_date"] == "2021-05-13Z"
+
+
+def test_get_po_title_with_title():
+    po_rec_1 = {"resource_metadata": {"title": "Book title"}}
+    assert credit_card_slips.get_po_title(po_rec_1) == "Book title"
+
+
+def test_get_po_title_without_title():
+    po_rec_2 = {"resource_metadata": {"title": None}}
+    assert credit_card_slips.get_po_title(po_rec_2) == "Unknown title"
+
+
+def test_load_xml_template():
+    root = credit_card_slips.load_xml_template("config/credit_card_slip_template.xml")
+    element_classes = [
+        "vendor",
+        "poline",
+        "item_title",
+        "price",
+        "po_date",
+        "invoice_num",
+        "credit_memo_num",
+        "account_1",
+        "account_2",
+        "cardholder",
+    ]
+    assert root.tag == "ccslip"
+    for element_class in element_classes:
+        assert root.find(f'.//td[@class="{element_class}"]') is not None
+
+
+def test_populate_credit_card_slip():
+    xml_template = credit_card_slips.load_xml_template(
+        "config/credit_card_slip_template.xml"
+    )
+    po_line_dict = {"poline": "POL-123", "item_title": "Book title"}
+    credit_card_slip = credit_card_slips.populate_credit_card_slip(
+        xml_template, po_line_dict
+    )
+    assert credit_card_slip.find('.//td[@class="poline"]').text == "POL-123"
+    assert credit_card_slip.find('.//td[@class="item_title"]').text == "Book title"
+
+
+def test_xml_data_from_dicts(mocked_alma, mocked_alma_env_vars):
+    po_line_dicts = [{"title": "Book title", "poline": "POL-123"}]
+    credit_card_slips_xml_string = credit_card_slips.xml_data_from_dicts(po_line_dicts)
+    credit_card_slips_xml = ET.fromstring(credit_card_slips_xml_string)
+    assert credit_card_slips_xml.find('.//td[@class="poline"]').text == "POL-123"

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,0 +1,29 @@
+from email.mime.multipart import MIMEMultipart
+
+import boto3
+from moto import mock_ses
+
+from llama import ses
+
+
+def test_ses_create_email():
+    message = ses.SES().create_email(
+        "Email subject",
+        "<html/>",
+        "attachment",
+    )
+    assert message["Subject"] == "Email subject"
+    assert message.get_payload()[0].get_filename() == "attachment"
+
+
+@mock_ses
+def test_ses_send_email():
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    message = message = MIMEMultipart()
+    response = ses.SES().send_email(
+        "noreply@example.com",
+        ["test@example.com"],
+        message,
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200


### PR DESCRIPTION
#### What does this PR do?
* Add CLI command to send credit card slips email
* Add Alma module containing class with methods to request PO line records via the API
* Add module with functions to create credit card slips
* Add SES module containing class with methods to create and send an email with attachment
* Add corresponding tests for CLI command, functions, and class methods
* Switch to defusedxml to fix potential security issues
* Add XML template for credit card slips
* Add bash script to run CLI command
* Add cron file for running bash script daily

#### Helpful background context
@zotoMIT is currently investigating the best way of populating the API_KEY and API_URL variables when running the bash script via cron. I'll issue another commit once that is settled.

#### How can a reviewer manually see the effects of these changes?
Run tests with `pipenv run pytest`. With an `API_KEY` env var set with an Alma API key with the appropriate Acquisitions read permissions on our production instance, you can send the credit slips email to yourself with `pipenv run llama cc-slips --source_email noreply@libraries.mit.edu --recipient_email YOUR@EMAIL.ADDRESS`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/INFRA-163

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
