### PR TITLE
Ignore spaces in titles when creating invoice number

### DIFF
--- a/llama/credit_card_slips.py
+++ b/llama/credit_card_slips.py
@@ -25,7 +25,7 @@ def create_po_line_dict(alma_api_client, po_line_record):
     po_line_dict["po_date"] = po_line_created_date
     po_line_dict[
         "invoice_num"
-    ] = f"Invoice #: {po_line_created_date}{title[:3].upper()}"
+    ] = f"Invoice #: {po_line_created_date}{title.replace(' ', '')[:3].upper()}"
 
     fund_code_1 = (
         po_line_record["fund_distribution"][0].get("fund_code", {}).get("value")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,23 @@ def po_line_record_multiple_funds():
 
 
 @pytest.fixture()
+def po_line_record_spaces_in_title():
+    po_line_record_spaces_in_title = {
+        "vendor_account": "Corporation",
+        "number": "POL-123",
+        "resource_metadata": {"title": "A title"},
+        "price": {"sum": "12.0"},
+        "created_date": "2021-05-13Z",
+        "fund_distribution": [
+            {"fund_code": {"value": "ABC"}, "amount": {"sum": "6.0"}},
+            {"fund_code": {"value": "DEF"}, "amount": {"sum": "6.0"}},
+        ],
+        "note": [{"note_text": ""}],
+    }
+    return po_line_record_spaces_in_title
+
+
+@pytest.fixture()
 def po_line_record_wrong_date():
     """A PO line record with the wrong date that should be filtered out."""
     po_line_record_all = {

--- a/tests/test_credit_card_slips.py
+++ b/tests/test_credit_card_slips.py
@@ -49,6 +49,18 @@ def test_create_po_line_dict_multiple_funds(
     assert po_line_dict_multiple_funds["account_2"] == "789"
 
 
+def test_create_po_line_dict_spaces_in_title(
+    mocked_alma,
+    mocked_alma_api_client,
+    po_line_record_spaces_in_title,
+):
+    po_line_dict_spaces_in_title = credit_card_slips.create_po_line_dict(
+        mocked_alma_api_client,
+        po_line_record_spaces_in_title,
+    )
+    assert po_line_dict_spaces_in_title["invoice_num"] == "Invoice #: 210513ATI"
+
+
 def test_create_po_line_dicts(
     mocked_alma, mocked_alma_api_client, po_line_record_all_fields
 ):


### PR DESCRIPTION
#### What does this PR do?
* Ignore title spaces for when grabbing the first 3 characters for the invoice number
* Add corresponding unit test and fixture

#### Helpful background context
This was requested by the stakeholders after discovering a title that began with "A star..." 

#### How can a reviewer manually see the effects of these changes?
Run tests with `pipenv run pytest`. The format of the report is unaffected, this is just a backend change.

#### What are the relevant tickets?

* https://mitlibraries.atlassian.net/browse/INFRA-184

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
