### PR TITLE
Update readme and cron job

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,17 @@ Files in this repo are sync'd to the alma-sftp-ec2 instance on the first deploym
 # Directories 
 ## Cron.d 
 This directory contains cron jobs, added to the cron.d directory on alma-sftp-ec2 automatically.  
+Cron job files MUST end in a newline. 
 
 ## scripts
 This directory contains the scripts that need to run on alma-sftp-ec2.
+Scripts should be "chmod +x" executable in order to run as a cron job successfully.  
+
+## SSM parameter store usage with alma-scripts
+* SSM parameters in the /apps/alma-sftp/ namespace are accessible by scripts in the alma-scripts repo
+* Parameters should be placed in the parameter store by developers in that path
+  * Secret parameters should be made type - `SecureString` and `Use the default KMS key for this account or specify a customer-managed key for this account.`
+
+## SES usage within alma-scripts
+* Emails from the SES service must come from `noreply@libraries.mit.edu` for this app 
 

--- a/cron.d/timdex-exports
+++ b/cron.d/timdex-exports
@@ -5,7 +5,9 @@
 #
 # # At 0030 on the 2nd of the month (runs on full export from the 1st of the
 # # month)
-30 0 5 * * gituser /mnt/alma/alma-scripts/scripts/Full-Export.sh
+#disabled semi permenantely for now due to - 
+# https://mitlibraries.atlassian.net/browse/IMP-2321
+#30 0 5 * * gituser /mnt/alma/alma-scripts/scripts/Full-Export.sh
 
 # do the git pull once a week, on monday, at 0005 
 5 0 * * 1 gituser /mnt/alma/alma-scripts/scripts/Gitrepo-pull.sh 


### PR DESCRIPTION
#### What does this PR do?
This PR updates the readme with some ssm information, and updates the cron job to completely disable the full update cron.

#### Helpful background context

Information about this update is primarily recorded in the ticket linked below.  The short version is that the full update needs to be run only when the export has been completed, so its easier to run by hand when we see that happen for now.  

https://mitlibraries.atlassian.net/browse/IMP-2321

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
