### PR TITLE
Remove scheduled git pull, implement update for patron load

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository contains scripts related to the Alma migration, and is primarily used in the alma-sftp-ec2 instance.  
 
 ## Important note: How to update files on the alma-sftp-ec2 instance. 
-Files in this repo are sync'd to the alma-sftp-ec2 instance on the first deployment of the machine, and from there, are sync'd once a week via cron job, or manually if the user needs a more urgent update.  
+Files in this repo are sync'd to the alma-sftp-ec2 instance on the first deployment of the machine, and from there, are manually synced when needed via `git pull` as the gituser. 
 
 # Directories 
 ## Cron.d 

--- a/cron.d/timdex-exports
+++ b/cron.d/timdex-exports
@@ -9,8 +9,5 @@
 # https://mitlibraries.atlassian.net/browse/IMP-2321
 #30 0 5 * * gituser /mnt/alma/alma-scripts/scripts/Full-Export.sh
 
-# do the git pull once a week, on monday, at 0005 
-5 0 * * 1 gituser /mnt/alma/alma-scripts/scripts/Gitrepo-pull.sh 
-
 #make sure to keep required newline at end of file -
 

--- a/patronload/.gitignore
+++ b/patronload/.gitignore
@@ -1,3 +1,5 @@
 patron.config
 STAFF/*.xml
 STUDENT/*.xml
+rejects_staff_script.txt
+rejects_students_script.txt

--- a/scripts/Patron-load.sh
+++ b/scripts/Patron-load.sh
@@ -26,3 +26,7 @@ perl scripts/pack_all_records.pl >> /mnt/alma/logs/patron-load.log 2>&1
 #Sync to the s3 bucket s3://alma-sftp-prod/exlibris/PatronLoad/
 # MV also deletes the zip files if they are succesfully copied
 aws s3 mv SEND/ s3://$ALMA_BUCKET/exlibris/PatronLoad/ --exclude "*" --include "*.zip" --recursive  >> /mnt/alma/logs/patron-load.log 2>&1
+
+# Remove the "rejects" files from the filesystem
+rm rejects_students_script.txt
+rm rejects_staff_script.txt

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,13 @@
 
 ## Full-Export.sh
 This bash script is used to download and combine multiple timdex files into one file, via concatenation and upload the result to the DIP ALEPH bucket
-This script will hopefully be cron'd to happen once a month
+This script is currently run by hand once per month, once we see the export has completed from alma
 
 ## Update-Export.sh
 This bash script follows the same process as the full update, but only occurs on the "updates" files that are deposited more frequently.  This file is not currently used, and is a template for later use.  
+
+## Patron-load.sh 
+This bash script compiles a list of staff and students and sends them to alma so it can create users for them.  
+
+## Credit-card-slips.sh
+This script calls the credit card slips function to compile a list of ??


### PR DESCRIPTION


#### What does this PR do?
This PR removes the scheduled once a week git pull because it was causing more issues than it was fixing.  
Its too hard to coordinate infrastructure changes and code changes properly when this is automatically pulling, and to date, its caused more issues than its fixed.
I add the two rejects files to gitignore.
I also implement a fix for https://mitlibraries.atlassian.net/browse/IMP-2335 and update some readme's


#### How can a reviewer manually see the effects of these changes?

The primary change here is rm'ing the two "rejects" files.   We can see this change by attempting a run on stage and seeing that the files dont exist after.  

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/IMP-2335


#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
