### PR TITLE
Source ENV in credit card slips bash script

### DIFF
--- a/scripts/Credit-Card-Slips.sh
+++ b/scripts/Credit-Card-Slips.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#source the environment variables here so that the script runs correctly for the cron user
+source /etc/profile
 
 #make the logs dir if it doesn't already exist
 mkdir /mnt/alma/logs


### PR DESCRIPTION
#### What does this PR do?
* Edit Credit-Card-Slips.sh to source env before running command

#### Helpful background context
Configuration changes interrupted the credit card slips emails as reported in ES-483 and this fix should allow them to resume

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/ES-483

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
