### PR TITLE
Refactor code to prevent KeyErrors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,20 +131,6 @@ def po_line_record_all_fields():
 
 
 @pytest.fixture()
-def po_line_record_missing_fields():
-    po_line_record_missing_fields = {
-        "vendor_account": "Corporation",
-        "number": "POL-123",
-        "resource_metadata": {"title": None},
-        "price": {"sum": "0.0"},
-        "created_date": "2021-05-13Z",
-        "fund_distribution": [{"fund_code": {"value": ""}, "amount": {"sum": ""}}],
-        "note": [],
-    }
-    return po_line_record_missing_fields
-
-
-@pytest.fixture()
 def po_line_record_multiple_funds():
     po_line_record_multiple_funds = {
         "vendor_account": "Corporation",

--- a/tests/test_credit_card_slips.py
+++ b/tests/test_credit_card_slips.py
@@ -25,16 +25,21 @@ def test_create_po_line_dict_all_fields(
 def test_create_po_line_dict_missing_fields(
     mocked_alma,
     mocked_alma_api_client,
-    po_line_record_missing_fields,
 ):
     po_line_dict_missing_fields = credit_card_slips.create_po_line_dict(
         mocked_alma_api_client,
-        po_line_record_missing_fields,
+        {},
     )
+    assert po_line_dict_missing_fields["vendor"] == "No vendor found"
+    assert po_line_dict_missing_fields["poline"] == "No PO Line number found"
+    assert po_line_dict_missing_fields["account_1"] == "No fund code found"
+    assert po_line_dict_missing_fields["po_date"] == "No PO Line created date found"
     assert po_line_dict_missing_fields["item_title"] == "Unknown title"
     assert po_line_dict_missing_fields["price"] == "$0.00"
-    assert po_line_dict_missing_fields["invoice_num"] == "Invoice #: 210513UNK"
-    assert po_line_dict_missing_fields["cardholder"] == "No cardholder note"
+    assert po_line_dict_missing_fields["invoice_num"] == (
+        "Invoice #: No PO Line created date foundUNK"
+    )
+    assert po_line_dict_missing_fields["cardholder"] == "No cardholder note found"
 
 
 def test_create_po_line_dict_multiple_funds(
@@ -90,8 +95,8 @@ def test_get_account_from_fund_code_with_fund_code(
 
 
 def test_get_account_from_fund_code_without_fund_code(mocked_alma_api_client):
-    account = credit_card_slips.get_account_from_fund_code(mocked_alma_api_client, "")
-    assert account == "No fund code"
+    account = credit_card_slips.get_account_from_fund_code(mocked_alma_api_client, None)
+    assert account == "No fund code found"
 
 
 def test_get_cardholder_from_notes_with_cardholder_note(
@@ -101,13 +106,9 @@ def test_get_cardholder_from_notes_with_cardholder_note(
     assert cardholder == "abc"
 
 
-def test_get_cardholder_from_notes_without_cardholder_note(
-    po_line_record_missing_fields,
-):
-    cardholder = credit_card_slips.get_cardholder_from_notes(
-        po_line_record_missing_fields
-    )
-    assert cardholder == "No cardholder note"
+def test_get_cardholder_from_notes_without_cardholder_note():
+    cardholder = credit_card_slips.get_cardholder_from_notes({})
+    assert cardholder == "No cardholder note found"
 
 
 def test_get_credit_card_full_po_lines_from_date(mocked_alma, mocked_alma_api_client):
@@ -117,6 +118,18 @@ def test_get_credit_card_full_po_lines_from_date(mocked_alma, mocked_alma_api_cl
     for po_line_record in po_line_records:
         assert po_line_record["resource_metadata"]["title"] == "Book title"
         assert po_line_record["created_date"] == "2021-05-13Z"
+
+
+def test_get_po_line_created_date_with_date(po_line_record_all_fields):
+    po_line_created_date = credit_card_slips.get_po_line_created_date(
+        po_line_record_all_fields
+    )
+    assert po_line_created_date == "210513"
+
+
+def test_get_po_line_created_date_without_date():
+    po_line_created_date = credit_card_slips.get_po_line_created_date({})
+    assert po_line_created_date == "No PO Line created date found"
 
 
 def test_get_po_title_with_title():


### PR DESCRIPTION
#### What does this PR do?
* Refactor code to ensure that no field is required and that error message are added instead of null values
* Create new function for getting PO Line created date
* Add corresponding unit test
* Refactor unit tests to ensure that code functions when passed a blank record
* Delete unnecessary fixture after refactor

#### Helpful background context
Based on a discussion with Helen, this refactor is intended to prevent `KeyError`s  from crashing the process if a particular field is absent. Some of these fields are very unlikely to be missing but now if a completely blank record is passed, the code will run and report out the necessary error messages. There was talk of excepting the `KeyError`s and sending an email about the bad data but since stakeholders already troubleshoot problematic data through the report itself, adding errors messages directly seems more efficient that setting up a separate message process.

#### How can a reviewer manually see the effects of these changes?
Run the refactored unit tests with `pipenv run pytest`

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
