### PR TITLE
Generate report from invoice data

### DIFF
--- a/llama/cli.py
+++ b/llama/cli.py
@@ -150,7 +150,8 @@ def sap_invoices(ctx, dry_run, final_run):
         f"    Final run: {final_run}\n"
     )
 
-    # Retrieve and sort invoices from Alma. Log result.
+    # Retrieve and sort invoices from Alma. Log result or abort process if no invoices
+    # retrieved.
     alma_client = Alma_API_Client(config.get_alma_api_key("ALMA_API_ACQ_READ_KEY"))
     alma_client.set_content_headers("application/json", "application/json")
     invoice_records = sap.retrieve_sorted_invoices(alma_client)
@@ -163,21 +164,49 @@ def sap_invoices(ctx, dry_run, final_run):
         raise click.Abort()
 
     # For each invoice retrieved, parse and extract invoice data and save to either
-    # monograph or serials invoice list depending on invoice type. Log result.
+    # monograph or serial invoice list depending on purchase type. Log result.
     monograph_invoices = []
     serial_invoices = []
-    for invoice_record in invoice_records:
+    retrieved_vendors = {}
+    retrieved_funds = {}
+    for count, invoice_record in enumerate(invoice_records):
+        logger.info(
+            f"Extracting data for invoice #{invoice_record['id']}, "
+            f"record {count} of {len(invoice_records)}"
+        )
         invoice_data = sap.extract_invoice_data(alma_client, invoice_record)
+        vendor_code = invoice_record["vendor"]["value"]
+        try:
+            invoice_data["vendor"] = retrieved_vendors[vendor_code]
+        except KeyError:
+            logger.info(f"Retrieving data for vendor {vendor_code}")
+            retrieved_vendors[vendor_code] = sap.populate_vendor_data(
+                alma_client, vendor_code
+            )
+            invoice_data["vendor"] = retrieved_vendors[vendor_code]
+        invoice_data["funds"], retrieved_funds = sap.populate_fund_data(
+            alma_client, invoice_record, retrieved_funds
+        )
         if invoice_data["type"] == "monograph":
             monograph_invoices.append(invoice_data)
         else:
             serial_invoices.append(invoice_data)
-    logger.info(f"{len(monograph_invoices)} monograph invoices processed.")
-    logger.info(f"{len(serial_invoices)} serial invoices processed.")
+    logger.info(
+        f"{len(monograph_invoices)} monograph invoices retrieved and extracted."
+    )
+    logger.info(f"{len(serial_invoices)} serial invoices retrieved and extracted.")
 
     # Generate formatted reports for review
+    logger.info("Generating monographs report")
+    monograph_report = sap.generate_report(ctx.obj["today"], monograph_invoices)
+    logger.info("Generating serials report")
+    serial_report = sap.generate_report(ctx.obj["today"], serial_invoices)
 
-    # If not dry run:
+    if dry_run:
+        logger.info(f"Monograph report:\n{monograph_report}")
+        logger.info(f"Serials report:\n{serial_report}")
+    else:
+        pass
     # Send email with reports as attachments (note that email subject and attachment
     # file names will differ for review vs. final run)
 
@@ -191,3 +220,10 @@ def sap_invoices(ctx, dry_run, final_run):
     # Send data and control files to SAP dropbox via SFTP
     # Email summary files
     # Update invoice statuses in Alma
+
+    logger.info(
+        "SAP invoice process completed for a review run:\n"
+        f"    {len(monograph_invoices)} monograph invoices retrieved and processed\n"
+        f"    {len(serial_invoices)} serial invoices retrieved and processed\n"
+        f"    {len(invoice_records)} total invoices retrieved and processed\n"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,23 @@ def mocked_alma(po_line_record_all_fields):
             ]
         }
         with open("tests/fixtures/funds.json") as f:
-            m.get("http://example.com/acq/funds", json=json.load(f))
+            funds = json.load(f)
+            m.get(
+                "http://example.com/acq/funds?q=fund_code~ABC",
+                json={"fund": [funds["fund"][0]]},
+            )
+            m.get(
+                "http://example.com/acq/funds?q=fund_code~DEF",
+                json={"fund": [funds["fund"][1]]},
+            )
+            m.get(
+                "http://example.com/acq/funds?q=fund_code~GHI",
+                json={"fund": [funds["fund"][2]]},
+            )
+            m.get(
+                "http://example.com/acq/funds?q=fund_code~JKL",
+                json={"fund": [funds["fund"][3]]},
+            )
         with open("tests/fixtures/invoices.json") as f:
             m.get(
                 "http://example.com/acq/invoices/0501130657",
@@ -154,7 +170,7 @@ def po_line_record_multiple_funds():
         "created_date": "2021-05-13Z",
         "fund_distribution": [
             {"fund_code": {"value": "ABC"}, "amount": {"sum": "6.0"}},
-            {"fund_code": {"value": "DEF"}, "amount": {"sum": "6.0"}},
+            {"fund_code": {"value": "GHI"}, "amount": {"sum": "6.0"}},
         ],
         "note": [{"note_text": ""}],
     }

--- a/tests/fixtures/funds.json
+++ b/tests/fixtures/funds.json
@@ -1,11 +1,146 @@
 {
-  "total_record_count": 999,
+  "total_record_count": 4,
   "fund": [
     {
       "link": "string",
       "code": "ABC",
       "name": "Biology",
-      "external_id": "1239410001021",
+      "external_id": "1234567-000001",
+      "type": {
+        "value": "General"
+      },
+      "entity_type": {
+        "value": "SUMMARY"
+      },
+      "owner": {
+        "value": "LAW"
+      },
+      "description": "desc",
+      "fiscal_period": {
+        "value": "29"
+      },
+      "currency": {
+        "value": "USD"
+      },
+      "available_for_library": [
+        {
+          "value": "string"
+        }
+      ],
+      "parent": {
+        "value": "43417015650001021"
+      },
+      "overencumbrance_allowed": {
+        "value": "yes"
+      },
+      "overexpenditure_allowed": {
+        "value": "no"
+      },
+      "overencumbrance_warning_percent": 15,
+      "overexpenditure_warning_sum": 17.44,
+      "overencumbrance_limit_percent": 8,
+      "overexpenditure_limit_sum": 10.44,
+      "encumbrances_prior_to_fiscal_period": 11,
+      "expenditures_prior_to_fiscal_period": 16,
+      "transfers_prior_to_fiscal_period": 12,
+      "fiscal_period_end_encumbrance_grace_period": 5,
+      "fiscal_period_end_expenditure_grace_period": 8
+    },
+    {
+      "link": "string",
+      "code": "DEF",
+      "name": "Fund DEF",
+      "external_id": "1234567-000001",
+      "type": {
+        "value": "General"
+      },
+      "entity_type": {
+        "value": "SUMMARY"
+      },
+      "owner": {
+        "value": "LAW"
+      },
+      "description": "desc",
+      "fiscal_period": {
+        "value": "29"
+      },
+      "currency": {
+        "value": "USD"
+      },
+      "available_for_library": [
+        {
+          "value": "string"
+        }
+      ],
+      "parent": {
+        "value": "43417015650001021"
+      },
+      "overencumbrance_allowed": {
+        "value": "yes"
+      },
+      "overexpenditure_allowed": {
+        "value": "no"
+      },
+      "overencumbrance_warning_percent": 15,
+      "overexpenditure_warning_sum": 17.44,
+      "overencumbrance_limit_percent": 8,
+      "overexpenditure_limit_sum": 10.44,
+      "encumbrances_prior_to_fiscal_period": 11,
+      "expenditures_prior_to_fiscal_period": 16,
+      "transfers_prior_to_fiscal_period": 12,
+      "fiscal_period_end_encumbrance_grace_period": 5,
+      "fiscal_period_end_expenditure_grace_period": 8
+    },
+    {
+      "link": "string",
+      "code": "GHI",
+      "name": "Fund GHI",
+      "external_id": "1234567-000002",
+      "type": {
+        "value": "General"
+      },
+      "entity_type": {
+        "value": "SUMMARY"
+      },
+      "owner": {
+        "value": "LAW"
+      },
+      "description": "desc",
+      "fiscal_period": {
+        "value": "29"
+      },
+      "currency": {
+        "value": "USD"
+      },
+      "available_for_library": [
+        {
+          "value": "string"
+        }
+      ],
+      "parent": {
+        "value": "43417015650001021"
+      },
+      "overencumbrance_allowed": {
+        "value": "yes"
+      },
+      "overexpenditure_allowed": {
+        "value": "no"
+      },
+      "overencumbrance_warning_percent": 15,
+      "overexpenditure_warning_sum": 17.44,
+      "overencumbrance_limit_percent": 8,
+      "overexpenditure_limit_sum": 10.44,
+      "encumbrances_prior_to_fiscal_period": 11,
+      "expenditures_prior_to_fiscal_period": 16,
+      "transfers_prior_to_fiscal_period": 12,
+      "fiscal_period_end_encumbrance_grace_period": 5,
+      "fiscal_period_end_expenditure_grace_period": 8
+    },
+    {
+      "link": "string",
+      "code": "JKL",
+      "name": "Fund JKL",
+      "external_id": "1234567-000003",
       "type": {
         "value": "General"
       },

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -33,7 +33,7 @@ def test_alma_get_brief_po_lines(mocked_alma, mocked_alma_api_client):
 def test_alma_get_fund_by_code(mocked_alma, mocked_alma_api_client):
     fund = mocked_alma_api_client.get_fund_by_code("ABC")
     assert fund["fund"][0]["code"] == "ABC"
-    assert fund["fund"][0]["external_id"] == "1239410001021"
+    assert fund["fund"][0]["external_id"] == "1234567-000001"
 
 
 def test_alma_get_invoice(mocked_alma, mocked_alma_api_client):

--- a/tests/test_credit_card_slips.py
+++ b/tests/test_credit_card_slips.py
@@ -12,7 +12,7 @@ def test_create_po_line_dict_all_fields(
         mocked_alma_api_client,
         po_line_record_all_fields,
     )
-    assert po_line_dict["account_1"] == "1239410001021"
+    assert po_line_dict["account_1"] == "1234567-000001"
     assert "account_2" not in po_line_dict
     assert po_line_dict["cardholder"] == "abc"
     assert po_line_dict["invoice_num"] == "Invoice #: 210513BOO"
@@ -46,7 +46,7 @@ def test_create_po_line_dict_multiple_funds(
         mocked_alma_api_client,
         po_line_record_multiple_funds,
     )
-    assert po_line_dict_multiple_funds["account_2"] == "1239410001021"
+    assert po_line_dict_multiple_funds["account_2"] == "1234567-000002"
 
 
 def test_create_po_line_dict_spaces_in_title(
@@ -69,7 +69,7 @@ def test_create_po_line_dicts(
         mocked_alma_api_client, po_line_records
     )
     for po_line_dict in po_line_dicts:
-        assert po_line_dict["account_1"] == "1239410001021"
+        assert po_line_dict["account_1"] == "1234567-000001"
         assert "account_2" not in po_line_dict
         assert po_line_dict["cardholder"] == "abc"
         assert po_line_dict["invoice_num"] == "Invoice #: 210513BOO"
@@ -86,7 +86,7 @@ def test_get_account_from_fund_code_with_fund_code(
     account = credit_card_slips.get_account_from_fund_code(
         mocked_alma_api_client, "ABC"
     )
-    assert account == "1239410001021"
+    assert account == "1234567-000001"
 
 
 def test_get_account_from_fund_code_without_fund_code(mocked_alma_api_client):


### PR DESCRIPTION
### What does this PR do?
This PR completes the refactor of `process-invoices/print_reports_by_status.py` by adding functionality
to generate reports from the Alma invoice data that can be sent to Acquisitions staff for review or as final cover sheets.

#### Detailed changes:
* Adds a function in `llama/sap.py`, `populate_fund_data()`, that completes the  invoice record data extraction process by extracting the necessary invoice line fund data, combining fund amounts with identical MIT account numbers, and returning the extracted fund data as a `dict`.
* Adds a function in `llama/sap.py`, `generate_report()`, that generates a human-readable report of data from an invoice data `dict`, structured according to requirements provided by stakeholders.
* Adds unit tests and updated fixtures for new functionality.
* Updates the `sap-invoices` CLI command to generate reports and log them if the `--dry-run` flag is passed. Emailing reports will be handled in a future commit.

### Side effects of this change:
The reports generated by this process are no longer written to output files, even during a dry run. It's possible we will want to change that back at some point if it turns out having them as files is useful during development, however it should not be needed in staging or production. In general, we would prefer not to write this information to files unless they are in a location that is excluded from version and control AND that gets automatically purged frequently, as these reports do contain sensitive data.

### How can a reviewer manually see the effects of these changes?
You can run this process and the old process locally, then compare the report output to see that results match:
* Make sure your local .env file has the following variables:
  ```
  WORKSPACE=dev
  ALMA_API_KEY=<the production read-only acquisitions API key>
  ```
* Run the old process with:
  ```
  git checkout main
  cd process-invoices
  pipenv run python print_reports_by_status.py
  ```
* Run the new process with:
  ```
  cd .. (back to the main alma-scripts folder)
  git checkout imp-2339-generate-invoice-report
  pipenv run llama sap-invoices --dry-run 2>&1 | tee tmp.log (saves the log output to a file that is already in .gitignore)
  ```
* Compare the old process reports (`process-invoices/output-files/review_mono_report_<DATE>.txt` and `process-invoices/output-files/review_ser_report_<DATE>.txt`) with the report section of the new process logfile (`tmp.log`).
* Please delete all output files when you've finished the local run!

### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/IMP-2339

### Includes new or updated dependencies?
NO
