### PR TITLE
extracts get_paged function

### DIFF
--- a/llama/alma.py
+++ b/llama/alma.py
@@ -19,29 +19,67 @@ class Alma_API_Client:
         self.headers["Accept"] = accept
         self.headers["Content-Type"] = content_type
 
+    def get_paged(
+        self,
+        endpoint,
+        record_type,
+        params=None,
+        limit=100,
+        _offset=0,
+        _records_retrieved=0,
+    ):
+        """Retrieve paginated results from the Alma API for a given endpoint.
+
+        Args:
+            endpoint: The paged Alma API endpoint to call, e.g. "acq/invoices".
+            record_type: The type of record returned by the Alma API for the specified
+                endpoint, e.g. "invoice" record_type returned by the "acq/invoices"
+                endpoint. See <https://developers.exlibrisgroup.com/alma/apis/docs/xsd/
+                rest_invoice.xsd/?tags=POST#invoice> for example.
+            params: Any endpoint-specific params to supply to the GET request.
+            limit: The maximum number of records to retrieve per page. Valid values are
+                0-100.
+            _offset: The offset value to supply to paged request. Should only be used
+                internally by this method's recursion.
+            _records_retrieved: The number of records retrieved so far for a given
+                paged endpoint. Should only be used internally by this method's
+                recursion.
+        """
+        params = params or {}
+        params["limit"] = limit
+        params["offset"] = _offset
+        response = requests.get(
+            url=f"{self.base_url}{endpoint}",
+            params=params,
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        time.sleep(0.1)
+        total_record_count = response.json()["total_record_count"]
+        records = response.json().get(record_type, [])
+        records_retrieved = _records_retrieved + len(records)
+        for record in records:
+            yield record
+        if records_retrieved < total_record_count:
+            yield from self.get_paged(
+                endpoint,
+                record_type,
+                params=params,
+                limit=limit,
+                _offset=_offset + limit,
+                _records_retrieved=records_retrieved,
+            )
+
     def get_brief_po_lines(self, acquisition_method=""):
         """Get brief PO lines with an option to narrow by acquisition_method. The
         PO line records retrieved from this endpoint do not contain all of the PO line
         data and users may wish to retrieve the full PO line record with the
         get_full_po_line method."""
-        po_line_payload = {
+        po_line_params = {
             "status": "ACTIVE",
-            "limit": "100",
-            "offset": 0,
             "acquisition_method": acquisition_method,
         }
-        brief_po_lines = ""
-        while brief_po_lines != []:
-            response = requests.get(
-                f"{self.base_url}acq/po-lines",
-                params=po_line_payload,
-                headers=self.headers,
-            ).json()
-            time.sleep(0.1)
-            brief_po_lines = response.get("po_line", [])
-            for brief_po_line in brief_po_lines:
-                yield brief_po_line
-            po_line_payload["offset"] += 100
+        return self.get_paged("acq/po-lines", "po_line", params=po_line_params)
 
     def get_full_po_line(self, po_line_id):
         """Get a full PO line record using the PO line ID."""
@@ -71,13 +109,10 @@ class Alma_API_Client:
 
     def get_invoices_by_status(self, status):
         """Get all invoices with a provided status."""
-        endpoint = f"{self.base_url}acq/invoices"
-        # TODO: handle paged requests
-        params = {"invoice_workflow_status": status, "limit": "100"}
-        r = requests.get(endpoint, headers=self.headers, params=params)
-        r.raise_for_status()
-        time.sleep(0.1)
-        return r.json()
+        invoice_params = {
+            "invoice_workflow_status": status,
+        }
+        return self.get_paged("acq/invoices", "invoice", params=invoice_params)
 
     def get_vendor_details(self, vendor_code):
         """Get vendor info from Alma."""

--- a/llama/sap.py
+++ b/llama/sap.py
@@ -18,8 +18,8 @@ def retrieve_sorted_invoices(alma_client):
     Retrieve invoices from Alma with status 'Waiting to be sent' and return them
     sorted by vendor code.
     """
-    data = alma_client.get_invoices_by_status("Waiting to be Sent")
-    return sorted(data["invoice"], key=lambda i: i["vendor"].get("value", 0))
+    data = list(alma_client.get_invoices_by_status("Waiting to be Sent"))
+    return sorted(data, key=lambda i: i["vendor"].get("value", 0))
 
 
 def extract_invoice_data(alma_client: Alma_API_Client, invoice_record: dict) -> dict:

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -43,8 +43,8 @@ def test_alma_get_invoice(mocked_alma, mocked_alma_api_client):
 
 def test_alma_get_invoices_by_status(mocked_alma, mocked_alma_api_client):
     invoices = mocked_alma_api_client.get_invoices_by_status("paid")
-    assert invoices["total_record_count"] == 2
-    assert invoices["invoice"][0]["payment"]["payment_status"]["value"] == "PAID"
+    assert next(invoices)["number"] == "0501130657"
+    assert next(invoices)["number"] == "0501130658"
 
 
 def test_alma_get_vendor_details(mocked_alma, mocked_alma_api_client):
@@ -65,3 +65,12 @@ def test_alma_mark_invoice_paid(mocked_alma):
         invoice_id="0501130657", invoice_xml_path="tests/fixtures/invoice_empty.xml"
     )
     assert "<number>0501130657</number>" in paid
+
+
+def test_alma_get_paged(mocked_alma, mocked_alma_api_client):
+    records = mocked_alma_api_client.get_paged(
+        endpoint="paged",
+        record_type="fake_records",
+        limit=10,
+    )
+    assert len(list(records)) == 15


### PR DESCRIPTION
#### What does this PR do?
extracts into a separate method of the Alma_API_Client the functionality to retrieve paged results from Alma API response. 
Adds this paging functionality to get_invoices_by_status and get_brief_po_lines methods

#### Helpful background context

the Alma API returns paginated results with a maximum of 100 records per page. Some of our calls to the API may return more than 100 records total.


#### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/IMP-2338

