### PR TITLE
ASI-14 generate summary

### DIFF
--- a/llama/sap.py
+++ b/llama/sap.py
@@ -307,3 +307,34 @@ def generate_sap_data(today: datetime, invoices: List[dict]) -> str:
             sap_data += " "
             sap_data += "\n"
     return sap_data
+
+
+def generate_summary(
+    invoices: List[dict], data_file_name: str, control_file_name: str
+) -> str:
+    excluded_invoices = ""
+    invoice_count = 0
+    sum_of_invoices = 0
+    summary = "--- MIT Libraries--- Alma to SAP Invoice Feed\n\n\n\n"
+    summary += f"Data file: {data_file_name}\n\n"
+    summary += f"Control file: {control_file_name}\n\n\n\n"
+
+    for invoice in invoices:
+        if invoice["payment method"] == "ACCOUNTINGDEPARTMENT":
+            summary += f"{invoice['vendor']['name']: <39.39}"
+            summary += (
+                f"{invoice['number'] + invoice['date'].strftime('%y%m%d'): <20.20}"
+            )
+            summary += f"{invoice['total amount']:.2f}\n"
+            sum_of_invoices += float(invoice["total amount"])
+            invoice_count += 1
+        else:
+            excluded_invoices += f"{invoice['payment method']}:\t"
+            excluded_invoices += f"{invoice['number']}\t"
+            excluded_invoices += f"{invoice['vendor']['name']}\t"
+            excluded_invoices += f"{invoice['vendor']['code']}\n"
+    summary += f"\nTotal payment:       ${sum_of_invoices:,.2f}\n\n"
+    summary += f"Invoice count:       {invoice_count}\n\n\n"
+    summary += "Authorized signature __________________________________\n\n\n"
+    summary += f"{excluded_invoices}"
+    return summary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import datetime
 
 import boto3
 import pytest
@@ -230,3 +231,116 @@ def runner():
 @pytest.fixture(scope="function")
 def s3():
     return S3()
+
+
+@pytest.fixture()
+def mono_invoices_with_different_payment_method():
+    """a list of monograph invoices which includes an invoice with
+    a payment method other than ACCOUNTINGDEPARTMENT which should
+    get filtered out when generating summary reports"""
+    monograph_invoices = [
+        {
+            "date": datetime(2021, 5, 12),
+            "id": "0000055555000000",
+            "number": "456789",
+            "type": "monograph",
+            "payment method": "ACCOUNTINGDEPARTMENT",
+            "total amount": 150,
+            "currency": "USD",
+            "vendor": {
+                "name": "Danger Inc.",
+                "code": "DANGER",
+                "address": {
+                    "lines": [
+                        "123 salad Street",
+                        "Second Floor",
+                    ],
+                    "city": "San Francisco",
+                    "state or province": "CA",
+                    "postal code": "94109",
+                    "country": "US",
+                },
+            },
+            "funds": {
+                "123456-0000001": {
+                    "amount": 150,
+                    "G/L account": "123456",
+                    "cost object": "0000001",
+                },
+            },
+        },
+        {
+            "date": datetime(2021, 5, 11),
+            "id": "0000055555000000",
+            "number": "444555",
+            "type": "monograph",
+            "payment method": "ACCOUNTINGDEPARTMENT",
+            "total amount": 1067.04,
+            "currency": "USD",
+            "vendor": {
+                "name": "some library solutions from salad",
+                "code": "YBPE-M",
+                "address": {
+                    "lines": [
+                        "P.O. Box 123456",
+                    ],
+                    "city": "Atlanta",
+                    "state or province": "GA",
+                    "postal code": "30384-7991",
+                    "country": "US",
+                },
+            },
+            "funds": {
+                "123456-0000001": {
+                    "amount": 608,
+                    "G/L account": "123456",
+                    "cost object": "0000001",
+                },
+                "123456-0000002": {
+                    "amount": 148.50,
+                    "G/L account": "123456",
+                    "cost object": "0000002",
+                },
+                "1123456-0000003": {
+                    "amount": 235.54,
+                    "G/L account": "123456",
+                    "cost object": "0000003",
+                },
+                "123456-0000004": {
+                    "amount": 75,
+                    "G/L account": "123456",
+                    "cost object": "0000004",
+                },
+            },
+        },
+        {
+            "date": datetime(2021, 5, 12),
+            "id": "0000055555000000",
+            "number": "12345",
+            "type": "monograph",
+            "payment method": "BAZ",
+            "total amount": 150,
+            "currency": "USD",
+            "vendor": {
+                "name": "Foo Bar Books",
+                "code": "FOOBAR",
+                "address": {
+                    "lines": [
+                        "123 some street",
+                    ],
+                    "city": "San Francisco",
+                    "state or province": "CA",
+                    "postal code": "94109",
+                    "country": "US",
+                },
+            },
+            "funds": {
+                "123456-0000001": {
+                    "amount": 150,
+                    "G/L account": "123456",
+                    "cost object": "0000001",
+                },
+            },
+        },
+    ]
+    return monograph_invoices

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -563,3 +563,37 @@ D\
  \
 \n"
     )
+
+
+def test_generate_summary(mono_invoices_with_different_payment_method):
+    dfile = "dlibsapg.1001.202110518000000"
+    cfile = "clibsapg.1001.202110518000000"
+    summary = sap.generate_summary(
+        mono_invoices_with_different_payment_method, dfile, cfile
+    )
+    assert (
+        summary
+        == """--- MIT Libraries--- Alma to SAP Invoice Feed
+
+
+
+Data file: dlibsapg.1001.202110518000000
+
+Control file: clibsapg.1001.202110518000000
+
+
+
+Danger Inc.                            456789210512        150.00
+some library solutions from salad      444555210511        1067.04
+
+Total payment:       $1,217.04
+
+Invoice count:       2
+
+
+Authorized signature __________________________________
+
+
+BAZ:\t12345\tFoo Bar Books\tFOOBAR
+"""
+    )


### PR DESCRIPTION
Why these changes are being introduced:
* This commit completes the refactor of make_summary.py by adding functionality to
generate summary reports from the Alma invoice data that can be sent to
Acquisitions Staff

How this addresses that need:
*  Adds a function in sap.py, generate_summary(), that generates a human-
  readable report of data from an invoice data dict, structured
  according to requirements provided by stakeholders.
*  information about invoices not being sent to SAP is included at the end of the reports
This was requested functionality that wasn't in make_summary.py and had previously
been done manually
*  Adds unit tests for new functionality.

Side effects of this change:
* The reports generated by this process are no longer printed to stdout.

Relevant ticket(s):
*  https://mitlibraries.atlassian.net/browse/ASI-14

