### PR TITLE
Generate sap control files

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -55,6 +55,14 @@
             "index": "pypi",
             "version": "==8.0.3"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "platform_system == 'Windows'",
+            "version": "==0.4.4"
+        },
         "cx-oracle": {
             "hashes": [
                 "sha256:12e7e913a7a10fd8caafb9855e6703a601b7dd5cc596fcd489d0ac9529608b6c",
@@ -216,6 +224,14 @@
             ],
             "version": "==1.4.4"
         },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
+                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==1.4.0"
+        },
         "attrs": {
             "hashes": [
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
@@ -333,6 +349,14 @@
             ],
             "index": "pypi",
             "version": "==8.0.3"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "platform_system == 'Windows'",
+            "version": "==0.4.4"
         },
         "coverage": {
             "extras": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,11 +220,121 @@ def s3():
 
 
 @pytest.fixture()
-def mono_invoices_with_different_payment_method():
-    """a list of monograph invoices which includes an invoice with
+def invoices_for_sap():
+    invoices = [
+        {
+            "date": datetime(2021, 5, 12),
+            "id": "0000055555000000",
+            "number": "456789",
+            "type": "monograph",
+            "payment method": "ACCOUNTINGDEPARTMENT",
+            "total amount": 150,
+            "currency": "USD",
+            "vendor": {
+                "name": "Danger Inc.",
+                "code": "FOOBAR-M",
+                "address": {
+                    "lines": [
+                        "123 salad Street",
+                        "Second Floor",
+                    ],
+                    "city": "San Francisco",
+                    "state or province": "CA",
+                    "postal code": "94109",
+                    "country": "US",
+                },
+            },
+            "funds": {
+                "123456-0000001": {
+                    "amount": 150,
+                    "G/L account": "123456",
+                    "cost object": "0000001",
+                },
+            },
+        },
+        {
+            "date": datetime(2021, 5, 11),
+            "id": "0000055555000000",
+            "number": "444555",
+            "type": "monograph",
+            "payment method": "ACCOUNTINGDEPARTMENT",
+            "total amount": 1067.04,
+            "currency": "USD",
+            "vendor": {
+                "name": "some library solutions from salad",
+                "code": "YBPE-M",
+                "address": {
+                    "lines": [
+                        "P.O. Box 123456",
+                    ],
+                    "city": "Atlanta",
+                    "state or province": "GA",
+                    "postal code": "30384-7991",
+                    "country": "US",
+                },
+            },
+            "funds": {
+                "123456-0000001": {
+                    "amount": 608,
+                    "G/L account": "123456",
+                    "cost object": "0000001",
+                },
+                "123456-0000002": {
+                    "amount": 148.50,
+                    "G/L account": "123456",
+                    "cost object": "0000002",
+                },
+                "1123456-0000003": {
+                    "amount": 235.54,
+                    "G/L account": "123456",
+                    "cost object": "0000003",
+                },
+                "123456-0000004": {
+                    "amount": 75,
+                    "G/L account": "123456",
+                    "cost object": "0000004",
+                },
+            },
+        },
+        {
+            "date": datetime(2021, 5, 12),
+            "id": "0000055555000000",
+            "number": "456789",
+            "type": "monograph",
+            "payment method": "ACCOUNTINGDEPARTMENT",
+            "total amount": 150,
+            "currency": "USD",
+            "vendor": {
+                "name": "one address line",
+                "code": "FOOBAR-M",
+                "address": {
+                    "lines": [
+                        "123 some street",
+                    ],
+                    "city": "San Francisco",
+                    "state or province": "CA",
+                    "postal code": "94109",
+                    "country": "US",
+                },
+            },
+            "funds": {
+                "123456-0000001": {
+                    "amount": 150,
+                    "G/L account": "123456",
+                    "cost object": "0000001",
+                },
+            },
+        },
+    ]
+    return invoices
+
+
+@pytest.fixture()
+def invoices_for_sap_with_different_payment_method():
+    """a list of invoices which includes an invoice with
     a payment method other than ACCOUNTINGDEPARTMENT which should
     get filtered out when generating summary reports"""
-    monograph_invoices = [
+    invoices = [
         {
             "date": datetime(2021, 5, 12),
             "id": "0000055555000000",
@@ -329,4 +439,122 @@ def mono_invoices_with_different_payment_method():
             },
         },
     ]
-    return monograph_invoices
+    return invoices
+
+
+@pytest.fixture()
+def sap_data_file():
+    """a string representing a datafile of invoices to send to SAP"""
+    # this test data is formatted to make it more readable
+    # each line corresponds to a field in the SAP data file spec
+    # See https://docs.google.com/spreadsheets/d/1PSEYSlPaQ0g2LTEIR6hdyBPzWrZLRK2K/
+    # edit#gid=1667272331
+    sap_data = "B\
+20210518\
+20210518\
+456789210512    \
+X000\
+400000\
+          150.00\
+ \
+ \
+  \
+    \
+ \
+X\
+Danger Inc.                        \
+San Francisco                      \
+123 salad Street                   \
+ \
+Second Floor                       \
+94109     \
+CA \
+US \
+                                                  \
+                                   \
+\n\
+D\
+123456    \
+0000001     \
+          150.00\
+ \
+\n\
+B\
+20210518\
+20210518\
+444555210511    \
+X000\
+400000\
+         1067.04\
+ \
+ \
+  \
+    \
+ \
+X\
+some library solutions from salad  \
+Atlanta                            \
+                                   \
+X\
+123456                             \
+30384-7991\
+GA \
+US \
+                                                  \
+                                   \
+\n\
+C\
+123456    \
+0000001     \
+          608.00\
+ \
+\n\
+C\
+123456    \
+0000002     \
+          148.50\
+ \
+\n\
+C\
+123456    \
+0000003     \
+          235.54\
+ \
+\n\
+D\
+123456    \
+0000004     \
+           75.00\
+ \
+\n\
+B\
+20210518\
+20210518\
+456789210512    \
+X000\
+400000\
+          150.00\
+ \
+ \
+  \
+    \
+ \
+X\
+one address line                   \
+San Francisco                      \
+123 some street                    \
+ \
+                                   \
+94109     \
+CA \
+US \
+                                                  \
+                                   \
+\n\
+D\
+123456    \
+0000001     \
+          150.00\
+ \
+\n"
+    return sap_data

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -347,235 +347,17 @@ def test_format_address_po_box_2_lines():
     assert payee_name_line_3 == " "
 
 
-def test_generate_sap_data_success():
+def test_generate_sap_data_success(invoices_for_sap, sap_data_file):
     today = datetime(2021, 5, 18)
-    invoices = [
-        {
-            "date": datetime(2021, 5, 12),
-            "id": "0000055555000000",
-            "number": "456789",
-            "type": "monograph",
-            "payment method": "ACCOUNTINGDEPARTMENT",
-            "total amount": 150,
-            "currency": "USD",
-            "vendor": {
-                "name": "Danger Inc.",
-                "code": "FOOBAR-M",
-                "address": {
-                    "lines": [
-                        "123 salad Street",
-                        "Second Floor",
-                    ],
-                    "city": "San Francisco",
-                    "state or province": "CA",
-                    "postal code": "94109",
-                    "country": "US",
-                },
-            },
-            "funds": {
-                "123456-0000001": {
-                    "amount": 150,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
-                },
-            },
-        },
-        {
-            "date": datetime(2021, 5, 11),
-            "id": "0000055555000000",
-            "number": "444555",
-            "type": "monograph",
-            "payment method": "ACCOUNTINGDEPARTMENT",
-            "total amount": 1067.04,
-            "currency": "USD",
-            "vendor": {
-                "name": "some library solutions from salad",
-                "code": "YBPE-M",
-                "address": {
-                    "lines": [
-                        "P.O. Box 123456",
-                    ],
-                    "city": "Atlanta",
-                    "state or province": "GA",
-                    "postal code": "30384-7991",
-                    "country": "US",
-                },
-            },
-            "funds": {
-                "123456-0000001": {
-                    "amount": 608,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
-                },
-                "123456-0000002": {
-                    "amount": 148.50,
-                    "G/L account": "123456",
-                    "cost object": "0000002",
-                },
-                "1123456-0000003": {
-                    "amount": 235.54,
-                    "G/L account": "123456",
-                    "cost object": "0000003",
-                },
-                "123456-0000004": {
-                    "amount": 75,
-                    "G/L account": "123456",
-                    "cost object": "0000004",
-                },
-            },
-        },
-        {
-            "date": datetime(2021, 5, 12),
-            "id": "0000055555000000",
-            "number": "456789",
-            "type": "monograph",
-            "payment method": "ACCOUNTINGDEPARTMENT",
-            "total amount": 150,
-            "currency": "USD",
-            "vendor": {
-                "name": "one address line",
-                "code": "FOOBAR-M",
-                "address": {
-                    "lines": [
-                        "123 some street",
-                    ],
-                    "city": "San Francisco",
-                    "state or province": "CA",
-                    "postal code": "94109",
-                    "country": "US",
-                },
-            },
-            "funds": {
-                "123456-0000001": {
-                    "amount": 150,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
-                },
-            },
-        },
-    ]
-    report = sap.generate_sap_data(today, invoices)
-    # test data is formatted to make it more readable
-    # each line corresponds to a field in the SAP data file spec
-    # See https://docs.google.com/spreadsheets/d/1PSEYSlPaQ0g2LTEIR6hdyBPzWrZLRK2K/
-    # edit#gid=1667272331
-    assert report == (
-        "B\
-20210518\
-20210518\
-456789210512    \
-X000\
-400000\
-          150.00\
- \
- \
-  \
-    \
- \
-X\
-Danger Inc.                        \
-San Francisco                      \
-123 salad Street                   \
- \
-Second Floor                       \
-94109     \
-CA \
-US \
-                                                  \
-                                   \
-\n\
-D\
-123456    \
-0000001     \
-          150.00\
- \
-\n\
-B\
-20210518\
-20210518\
-444555210511    \
-X000\
-400000\
-         1067.04\
- \
- \
-  \
-    \
- \
-X\
-some library solutions from salad  \
-Atlanta                            \
-                                   \
-X\
-123456                             \
-30384-7991\
-GA \
-US \
-                                                  \
-                                   \
-\n\
-C\
-123456    \
-0000001     \
-          608.00\
- \
-\n\
-C\
-123456    \
-0000002     \
-          148.50\
- \
-\n\
-C\
-123456    \
-0000003     \
-          235.54\
- \
-\n\
-D\
-123456    \
-0000004     \
-           75.00\
- \
-\n\
-B\
-20210518\
-20210518\
-456789210512    \
-X000\
-400000\
-          150.00\
- \
- \
-  \
-    \
- \
-X\
-one address line                   \
-San Francisco                      \
-123 some street                    \
- \
-                                   \
-94109     \
-CA \
-US \
-                                                  \
-                                   \
-\n\
-D\
-123456    \
-0000001     \
-          150.00\
- \
-\n"
-    )
+    report = sap.generate_sap_data(today, invoices_for_sap)
+    assert report == sap_data_file
 
 
-def test_generate_summary(mono_invoices_with_different_payment_method):
+def test_generate_summary(invoices_for_sap_with_different_payment_method):
     dfile = "dlibsapg.1001.202110518000000"
     cfile = "clibsapg.1001.202110518000000"
     summary = sap.generate_summary(
-        mono_invoices_with_different_payment_method, dfile, cfile
+        invoices_for_sap_with_different_payment_method, dfile, cfile
     )
     assert (
         summary
@@ -603,3 +385,15 @@ Authorized signature __________________________________
 BAZ:\t12345\tFoo Bar Books\tFOOBAR
 """
     )
+
+
+def test_generate_sap_control(sap_data_file):
+    invoice_total = 1367.04
+    sap_control = sap.generate_sap_control(sap_data_file, invoice_total)
+    assert sap_control[0:16] == "0000000000001182"
+    assert sap_control[16:32] == "0000000000000009"
+    assert sap_control[32:52] == "00000000000000000000"
+    assert sap_control[52:72] == "00000000000000136704"
+    assert sap_control[72:92] == "00000000000000136704"
+    assert sap_control[92:112] == "00100100000000000000"
+    assert len(sap_control.encode("utf-8")) == 113


### PR DESCRIPTION
Why these changes are being introduced:
Invoice data files sent to SAP must be accompanied by corresponding control files in a
particular format. See https://wikis.mit.edu/confluence/display/SAPdev/MIT+SAP+Dropbox

How this addresses that need:
* creates a function which takes an SAP data file (a string) and an invoice total for that data file
and returns a correctly formated control file (a string)

Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ASI-13