### PR TITLE
Email summary files, update config messages and PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -20,12 +20,25 @@ Delete this section if it isn't applicable to the PR.
 
 - https://mitlibraries.atlassian.net/browse/DIP-
 
-#### Screenshots (if appropriate)
-
-Delete this section if it isn't applicable to the PR.
-
-#### Requires Database Migrations?
-YES | NO
-
 #### Includes new or updated dependencies?
+
 YES | NO
+
+#### Changes expectations for external applications?
+
+YES | NO
+
+#### Developer
+
+- [ ] All new config values are documented in README
+- [ ] All new config values have been added to staging and production environments
+- [ ] All related Jira tickets are linked in commit message(s)
+
+#### Code Reviewer
+
+- [ ] The commit message is clear and follows our guidelines
+      (not just this pull request message)
+- [ ] There are appropriate tests covering any new functionality
+- [ ] The documentation has been updated or is unnecessary
+- [ ] The changes have been verified
+- [ ] New dependencies are appropriate or there were no changes

--- a/llama/cli.py
+++ b/llama/cli.py
@@ -218,16 +218,50 @@ def sap_invoices(ctx, dry_run, final_run):
             "Serials report email sent with message ID: %s", response["MessageId"]
         )
 
-    # If final run:
-    # Generate data files to send to SAP (updating sequence numbers from SSM in the
-    # process
-    # Generate control files to send to SAP
-    # Generate summary files
+    if final_run:
+        # Generate next sequence numbers from SSM and create data and control file names
+        monograph_data_file_name = "TODO: monos-data-file-name-from-sequence-number"
+        serial_data_file_name = "TODO: serials-data-file-name-from-sequence-number"
+        monograph_control_file_name = (
+            "TODO: monos-control-file-name-from-sequence-number"
+        )
+        serial_control_file_name = (
+            "TODO: serials-control-file-name-from-sequence-number"
+        )
 
-    # If not dry run:
-    # Send data and control files to SAP dropbox via SFTP
-    # Email summary files
-    # Update invoice statuses in Alma
+        # Generate data files to send to SAP
+
+        # Generate control files to send to SAP
+
+        # Generate summary files
+        logger.info("Final run, generating summary files")
+        monograph_summary = sap.generate_summary(
+            monograph_invoices, monograph_data_file_name, monograph_control_file_name
+        )
+        serial_summary = sap.generate_summary(
+            serial_invoices, serial_data_file_name, serial_control_file_name
+        )
+
+        if dry_run:
+            logger.info(f"Monographs summary:\n{monograph_summary}")
+            logger.info(f"Serials summary:\n{serial_summary}")
+        else:
+            # Send data and control files to SAP dropbox via SFTP
+
+            # Update sequence numbers in SSM
+
+            # Email summary files
+            response = sap.email_summary(monograph_summary, ctx.obj["today"])
+            logger.info(
+                "Monographs summary email sent with message ID: %s",
+                response["MessageId"],
+            )
+            response = sap.email_summary(serial_summary, ctx.obj["today"])
+            logger.info(
+                "Serials summary email sent with message ID: %s", response["MessageId"]
+            )
+
+            # Update invoice statuses in Alma
 
     run_type = "final" if final_run else "review"
     logger.info(

--- a/llama/sap.py
+++ b/llama/sap.py
@@ -213,12 +213,12 @@ def email_report(
 ):
     report_email = Email()
     if final:
-        subject_string = f"Coversheets – {report_type}s - {date.strftime('%Y%M%D')}"
+        subject_string = f"Coversheets - {report_type}s - {date.strftime('%Y%m%d')}"
         attachment_name = (
             f"cover_sheets_{report_type}_{date.strftime('%Y%m%d%H%M%S')}.txt"
         )
     else:
-        subject_string = f"Review Report – {report_type}s - {date.strftime('%Y%M%D')}"
+        subject_string = f"Review Report - {report_type}s - {date.strftime('%Y%m%d')}"
         attachment_name = (
             f"review_{report_type}_report_{date.strftime('%Y%m%d%H%M%S')}.txt"
         )
@@ -367,6 +367,20 @@ def generate_summary(
     summary += "Authorized signature __________________________________\n\n\n"
     summary += f"{excluded_invoices}"
     return summary
+
+
+def email_summary(summary: str, date: datetime):
+    subject_string = f"Libraries invoice feed {date.strftime('%Y%m%d')}"
+    summary_email = Email()
+    summary_email.populate(
+        from_address=CONFIG.SES_SEND_FROM_EMAIL,
+        to_addresses=CONFIG.SAP_SUMMARY_RECIPIENT_EMAILS,
+        reply_to=CONFIG.SAP_REPLY_TO_EMAIL,
+        subject=subject_string,
+        body=summary,
+    )
+    response = summary_email.send()
+    return response
 
 
 def generate_sap_control(sap_data_file: str, invoice_total: float) -> str:

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -391,6 +391,12 @@ BAZ:\t12345\tFoo Bar Books\tFOOBAR
     )
 
 
+def test_email_summary_success(mocked_ses):
+    response = sap.email_summary("Summary contents", datetime(2021, 10, 1))
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["MessageId"]
+
+
 def test_generate_sap_control(sap_data_file):
     invoice_total = 1367.04
     sap_control = sap.generate_sap_control(sap_data_file, invoice_total)


### PR DESCRIPTION
#### What does this PR do?
Adds logic to generate and email summary files during a sap-invoices final run, or generate and log them in a dry final run.
Also updates the PR template and adds some extra error messages and checking during configuration loading.

#### How can a reviewer manually see the effects of these changes?
Make sure that the following config values are set locally in your .env:
```
ALMA_API_URL: <Alma API URL>
SAP_REPLY_TO_EMAIL: <any email address>
SAP_REPORT_RECIPIENT_EMAILS: <your email address>
SAP_SUMMARY_RECIPIENT_EMAILS: <your email address>
SES_SEND_FROM_EMAIL: noreply@libraries.mit.edu
```
Then run the llama sap-invoice command. `pipenv run llama sap-invoices --final-run --dry-run` will now show summaries in the log output. The same command without the `--dry-run` flag will send you four emails: the two report (cover sheet) emails and the two summary emails.

PR template changes will not show up until the next PR (they have been manually pasted here). 

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/ASI-16

#### Includes new or updated dependencies?

NO

#### Changes expectations for external applications?

NO

#### Developer

- NA All new config values are documented in README
- NA All new config values have been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
