### PR TITLE
Add command to create sandbox sample data for SAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,29 @@ To use:
      ssm.update_parameter_value("/dev/SAP_SEQUENCE", "1001,20210722000000,ser", "StringList")
       ```
 
+### Creating sample SAP data
+Running the SAP Invoices process during local development or on staging requires that
+there be sample invoices ready to be paid in the Alma sandbox. To simplify this, there
+is a CLI command that will create four sample invoices in the sandbox. To do this:
+  1. Make sure the following variables are set in your `.env`:
+     ```
+     WORKSPACE=dev
+     SSM_PATH=/dev/ (you don't need any SSM parameters created locally for this command,
+        but config still requires a path in env)
+     ALMA_API_URL=<the Alma API base URL>
+     ALMA_API_ACQ_READ_WRITE_KEY=<the SANDBOX Alma Acq read/write key>
+     ```
+  2. Run `pipenv run llama create-sandbox-sap-data`. You should get a final log message
+     saying there are four invoices ready for manual approval in Alma.
+  3. Go to the Alma sandbox UI > Acquisitions module > Review (Invoice) > Unassigned
+     tab. There should be four invoices listed whose numbers start with TestSAPInvoice.
+  4. For each of those invoices, click on it and then click "Save and Continue". They
+     will now show up in the Waiting For Approval Invoices queue.
+  5. From that queue, using the three dots to the right of each invoice, choose "Edit"
+     and then click "Approve" in the upper right corner.
+  6. Once the invoices have been approved, they are ready to be paid and will be
+     retrieved and processed using the llama sap-invoices CLI command.
+
+Note that sample invoices will remain in the Alma sandbox in the "Waiting to be Sent"
+status until a "real", "final" sap-invoices process has been run, at which point they
+will be marked as paid and new sample invoices will need to be created.

--- a/llama/alma.py
+++ b/llama/alma.py
@@ -21,6 +21,29 @@ class Alma_API_Client:
         self.headers["Accept"] = accept
         self.headers["Content-Type"] = content_type
 
+    def create_invoice(self, invoice_json):
+        endpoint = f"{self.base_url}acq/invoices"
+        r = requests.post(endpoint, headers=self.headers, data=json.dumps(invoice_json))
+        r.raise_for_status()
+        time.sleep(0.1)
+        return r.json()
+
+    def create_invoice_line(self, invoice_id, invoice_line_json):
+        endpoint = f"{self.base_url}acq/invoices/{invoice_id}/lines"
+        r = requests.post(
+            endpoint, headers=self.headers, data=json.dumps(invoice_line_json)
+        )
+        r.raise_for_status()
+        time.sleep(0.1)
+        return r.json()
+
+    def create_vendor(self, vendor_json):
+        endpoint = f"{self.base_url}acq/vendors"
+        r = requests.post(endpoint, headers=self.headers, data=json.dumps(vendor_json))
+        r.raise_for_status()
+        time.sleep(0.1)
+        return r.json()
+
     def get_paged(
         self,
         endpoint,
@@ -123,6 +146,10 @@ class Alma_API_Client:
         time.sleep(0.1)
         return r.json()
 
+    def get_vendor_invoices(self, vendor_code):
+        endpoint = f"acq/vendors/{vendor_code}/invoices"
+        return self.get_paged(endpoint, "invoice")
+
     def mark_invoice_paid(
         self,
         invoice_id: str,
@@ -153,4 +180,13 @@ class Alma_API_Client:
         # UE9TVCAvYWxtYXdzL3YxL2FjcS9pbnZvaWNlcy97aW52b2ljZV9pZH0=/ and https://
         # developers.exlibrisgroup.com/blog/Creating-an-invoice-using-APIs/ for more
         # info.
+        return r.json()
+
+    def process_invoice(self, invoice_id):
+        """Move an invoice to in process using the invoice process endpoint."""
+        endpoint = f"{self.base_url}acq/invoices/{invoice_id}"
+        params = {"op": "process_invoice"}
+        r = requests.post(endpoint, headers=self.headers, params=params, data="{}")
+        r.raise_for_status()
+        time.sleep(0.1)
         return r.json()

--- a/llama/sample_data.py
+++ b/llama/sample_data.py
@@ -1,0 +1,134 @@
+"""Sample data loader."""
+import json
+import logging
+from typing import List
+
+from requests.exceptions import HTTPError
+
+from llama.alma import Alma_API_Client
+
+logger = logging.getLogger(__name__)
+
+
+def load_sample_data(
+    alma_client: Alma_API_Client, sample_data_file_contents: dict
+) -> None:
+    invoice_count = 0
+    for vendor in sample_data_file_contents:
+        vendor_code = create_vendor_if_needed(
+            alma_client, sample_data_file_contents[vendor]["vendor_data"]
+        )
+        next_invoice_number = get_next_vendor_invoice_number(alma_client, vendor_code)
+        invoice_ids = create_invoices_with_lines(
+            alma_client,
+            sample_data_file_contents[vendor]["invoices"],
+            sample_data_file_contents[vendor]["abbreviation"],
+            next_invoice_number,
+        )
+        process_invoices(alma_client, invoice_ids)
+        invoice_count += len(invoice_ids)
+    return invoice_count
+
+
+def create_vendor_if_needed(alma_client: Alma_API_Client, vendor_data: dict) -> str:
+    """Check if vendor exists in Alma, if not create it."""
+    try:
+        vendor_code = vendor_data["code"]
+        alma_client.get_vendor_details(vendor_code)
+        logger.info(f"Vendor '{vendor_code}' already exists in Alma, not creating it")
+    except HTTPError as e:
+        if any(
+            item.get("errorCode") == "402880"  # Code for vendor not found
+            for item in e.response.json().get("errorList", {}).get("error", {})
+        ):
+            response_vendor_code = alma_client.create_vendor(vendor_data)["code"]
+            logger.info(f"Vendor '{response_vendor_code}' created in Alma")
+        else:
+            logger.error(e.response.text)
+            raise e
+    return vendor_code
+
+
+def get_next_vendor_invoice_number(
+    alma_client: Alma_API_Client, vendor_code: str
+) -> int:
+    latest_number = 0
+    vendor_invoices = alma_client.get_vendor_invoices(vendor_code)
+    for invoice in vendor_invoices:
+        invoice_number = invoice["number"]
+        try:
+            number_index = invoice_number.index("-") + 1
+        except ValueError:
+            continue
+        number = int(invoice_number[number_index:])
+        if number > latest_number:
+            latest_number = number
+    return latest_number + 1
+
+
+def create_invoices_with_lines(
+    alma_client: Alma_API_Client,
+    invoices: List[dict],
+    vendor_abbreviation: str,
+    next_invoice_number: int,
+):
+    created_invoice_ids = []
+    for invoice in invoices:
+        invoice_number = f"TestSAPInvoice{vendor_abbreviation}-{next_invoice_number}"
+        invoice["post_json"]["number"] = invoice_number
+        invoice_alma_id = create_invoice(alma_client, invoice["post_json"])
+        created_invoice_ids.append(invoice_alma_id)
+
+        lines_created = create_invoice_lines(
+            alma_client, invoice_alma_id, invoice["invoice_lines"]
+        )
+        logger.info(f"Created invoice '{invoice_number}' with {lines_created} lines")
+
+        next_invoice_number += 1
+    return created_invoice_ids
+
+
+def create_invoice(alma_client: Alma_API_Client, invoice_data: dict) -> str:
+    """Create invoice in Alma and return invoice ID."""
+    try:
+        response = alma_client.create_invoice(invoice_data)
+        logger.info(f"Invoice created with data: {json.dumps(response)}")
+        return response["id"]
+    except HTTPError as e:
+        logger.error(e.response.text)
+        raise e
+
+
+def create_invoice_lines(
+    alma_client: Alma_API_Client, invoice_alma_id: str, invoice_lines: List[dict]
+) -> None:
+    """Create invoice lines for a given invoice in Alma."""
+    created_lines = 0
+    for line in invoice_lines:
+        try:
+            response = alma_client.create_invoice_line(invoice_alma_id, line)
+            logger.info(
+                f"Invoice line created for invoice '{invoice_alma_id}' with data: "
+                f"{json.dumps(response)}"
+            )
+            created_lines += 1
+        except HTTPError as e:
+            logger.error(e.response.text)
+            raise e
+    return created_lines
+
+
+def process_invoices(alma_client: Alma_API_Client, invoice_alma_ids: str) -> None:
+    processed = 0
+    for invoice_id in invoice_alma_ids:
+        try:
+            response = alma_client.process_invoice(invoice_id)
+            logger.info(
+                f"Invoice '{invoice_id}' processed in Alma with response: "
+                f"{json.dumps(response)}"
+            )
+            processed += 1
+        except HTTPError as e:
+            logger.error(e.response.text)
+            raise e
+    return processed

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ env =
   WORKSPACE=test
   SSM_PATH=/test/example/
   ALMA_API_ACQ_READ_KEY=abc123
+  ALMA_API_ACQ_READ_WRITE_KEY=abc123
   ALMA_API_URL=http://example.com/
   ALMA_DATA_WAREHOUSE_USER=test_dw_user
   ALMA_DATA_WAREHOUSE_PASSWORD=test_dw_password

--- a/sample-data/sample-sap-invoice-data.json
+++ b/sample-data/sample-sap-invoice-data.json
@@ -1,0 +1,512 @@
+{
+  "mono_vendor": {
+    "abbreviation": "V1",
+    "vendor_data": {
+      "code": "TestSAPVendor1",
+      "name": "Test SAP Vendor 1",
+      "status": {
+        "value": "ACTIVE",
+        "desc": "Active"
+      },
+      "liable_for_vat": false,
+      "language": {
+        "value": "en",
+        "desc": "English"
+      },
+      "material_supplier": true,
+      "access_provider": false,
+      "licensor": false,
+      "governmental": false,
+      "library": [
+        {
+          "code": {
+            "value": "01MIT_INST",
+            "desc": "Massachusetts Institute of Technology"
+          },
+          "include_sub_units": true
+        }
+      ],
+      "currency": [
+        {
+          "value": "USD",
+          "desc": "US Dollar"
+        }
+      ],
+      "account": [
+        {
+          "code": "TestSAPVendor1",
+          "description": "Default Account - TestSAPVendor1",
+          "status": {
+            "value": "ACTIVE",
+            "desc": "Active"
+          },
+          "library": [
+            {
+              "code": {
+                "value": "01MIT_INST",
+                "desc": "Massachusetts Institute of Technology"
+              },
+              "include_sub_units": true
+            }
+          ],
+          "payment_method": [
+            {
+              "value": "ACCOUNTINGDEPARTMENT",
+              "desc": "Accounting Department"
+            },
+            {
+              "value": "CREDITCARD",
+              "desc": "Credit card"
+            }
+          ]
+        }
+      ],
+      "contact_info": {
+        "address": [
+          {
+            "line1": "123 Sesame Street",
+            "line2": "C/O Big Bird",
+            "city": "Anytown",
+            "postal_code": "12345",
+            "country": {
+              "value": "USA"
+            },
+            "address_type": [
+              {
+                "value": "payment",
+                "desc": "Payment"
+              }
+            ],
+            "preferred": true
+          }
+        ]
+      }
+    },
+    "invoices": [
+      {
+        "description": "Monograph invoice paid via SAP",
+        "post_json": {
+          "vendor": {
+            "value": "TestSAPVendor1",
+            "desc": "Test SAP Vendor 1"
+          },
+          "owner": {
+            "value": "01MIT_INST",
+            "desc": "Massachusetts Institute of Technology"
+          },
+          "invoice_date": "2022-01-12Z",
+          "total_amount": 100,
+          "currency": {
+            "value": "USD",
+            "desc": "US Dollar"
+          },
+          "total_invoice_lines_amount": 100,
+          "vendor_contact_person": {},
+          "payment_method": {
+            "value": "ACCOUNTINGDEPARTMENT",
+            "desc": "Accounting Department"
+          },
+          "reference_number": "",
+          "additional_charges": {
+            "use_pro_rata": false,
+            "shipment": 0,
+            "overhead": 0,
+            "insurance": 0,
+            "discount": 0
+          },
+          "invoice_vat": {
+            "report_tax": false,
+            "vat_per_invoice_line": false,
+            "vat_code": {
+              "value": "",
+              "desc": null
+            },
+            "percentage": 0,
+            "vat_amount": 0,
+            "type": {
+              "value": "INCLUSIVE",
+              "desc": "Inclusive"
+            },
+            "expended_from_fund": false
+          },
+          "explicit_ratio": [],
+          "payment": {
+            "prepaid": false,
+            "internal_copy": false,
+            "payment_status": {
+              "value": "NOT_PAID",
+              "desc": "Not Paid"
+            },
+            "voucher_date": "2022-01-12Z",
+            "voucher_number": "",
+            "voucher_amount": "0",
+            "voucher_currency": {
+              "value": "USD",
+              "desc": "US Dollar"
+            }
+          }
+        },
+        "invoice_lines": [
+          {
+            "type": {
+              "value": "REGULAR",
+              "desc": "Regular"
+            },
+            "number": "1",
+            "price": 100,
+            "total_price": 100,
+            "quantity": 1,
+            "fund_distribution": [
+              {
+                "fund_code": {
+                  "value": "C-IRC-HCAT",
+                  "desc": "Onsite Cataloging"
+                },
+                "amount": 100
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "Description": "Monograph invoice not paid via SAP",
+        "post_json": {
+          "vendor": {
+            "value": "TestSAPVendor1",
+            "desc": "Test SAP Vendor 1"
+          },
+          "owner": {
+            "value": "01MIT_INST",
+            "desc": "Massachusetts Institute of Technology"
+          },
+          "invoice_date": "2022-01-12Z",
+          "total_amount": 100,
+          "currency": {
+            "value": "USD",
+            "desc": "US Dollar"
+          },
+          "total_invoice_lines_amount": 100,
+          "vendor_contact_person": {},
+          "payment_method": {
+            "value": "CREDITCARD",
+            "desc": "Credit card"
+          },
+          "reference_number": "",
+          "additional_charges": {
+            "use_pro_rata": false,
+            "shipment": 0,
+            "overhead": 0,
+            "insurance": 0,
+            "discount": 0
+          },
+          "invoice_vat": {
+            "report_tax": false,
+            "vat_per_invoice_line": false,
+            "vat_code": {
+              "value": "",
+              "desc": null
+            },
+            "percentage": 0,
+            "vat_amount": 0,
+            "type": {
+              "value": "INCLUSIVE",
+              "desc": "Inclusive"
+            },
+            "expended_from_fund": false
+          },
+          "explicit_ratio": [],
+          "payment": {
+            "prepaid": false,
+            "internal_copy": false,
+            "payment_status": {
+              "value": "NOT_PAID",
+              "desc": "Not Paid"
+            },
+            "voucher_date": "2022-01-12Z",
+            "voucher_number": "",
+            "voucher_amount": "0",
+            "voucher_currency": {
+              "value": "USD",
+              "desc": "US Dollar"
+            }
+          }
+        },
+        "invoice_lines": [
+          {
+            "type": {
+              "value": "REGULAR",
+              "desc": "Regular"
+            },
+            "number": "1",
+            "price": 100,
+            "total_price": 100,
+            "quantity": 1,
+            "fund_distribution": [
+              {
+                "fund_code": {
+                  "value": "C-IRC-HCAT",
+                  "desc": "Onsite Cataloging"
+                },
+                "amount": 100
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "serial_vendor": {
+    "abbreviation": "V2",
+    "vendor_data": {
+      "code": "TestSAPVendor2-S",
+      "name": "Test SAP Vendor 2 Serials",
+      "status": {
+        "value": "ACTIVE",
+        "desc": "Active"
+      },
+      "liable_for_vat": false,
+      "language": {
+        "value": "en",
+        "desc": "English"
+      },
+      "material_supplier": true,
+      "access_provider": false,
+      "licensor": false,
+      "governmental": false,
+      "library": [
+        {
+          "code": {
+            "value": "01MIT_INST",
+            "desc": "Massachusetts Institute of Technology"
+          },
+          "include_sub_units": true
+        }
+      ],
+      "currency": [
+        {
+          "value": "USD",
+          "desc": "US Dollar"
+        }
+      ],
+      "account": [
+        {
+          "code": "TestSAPVendor2-S",
+          "description": "Default Account - TestSAPVendor2-S",
+          "status": {
+            "value": "ACTIVE",
+            "desc": "Active"
+          },
+          "library": [
+            {
+              "code": {
+                "value": "01MIT_INST",
+                "desc": "Massachusetts Institute of Technology"
+              },
+              "include_sub_units": true
+            }
+          ],
+          "payment_method": [
+            {
+              "value": "ACCOUNTINGDEPARTMENT",
+              "desc": "Accounting Department"
+            },
+            {
+              "value": "SPECIALPAYMENT",
+              "desc": "Special payment"
+            }
+          ]
+        }
+      ],
+      "contact_info": {
+        "address": [
+          {
+            "line1": "PO Box 1234",
+            "postal_code": "56789",
+            "country": {
+              "value": "USA"
+            },
+            "address_type": [
+              {
+                "value": "order",
+                "desc": "Order"
+              }
+            ],
+            "preferred": true
+          }
+        ]
+      }
+    },
+    "invoices": [
+      {
+        "description": "Serials invoice not paid via SAP",
+        "post_json": {
+          "vendor": {
+            "value": "TestSAPVendor2-S",
+            "desc": "Test SAP Vendor 2 Serials"
+          },
+          "owner": {
+            "value": "01MIT_INST",
+            "desc": "Massachusetts Institute of Technology"
+          },
+          "invoice_date": "2022-01-12Z",
+          "total_amount": 100,
+          "currency": {
+            "value": "USD",
+            "desc": "US Dollar"
+          },
+          "total_invoice_lines_amount": 100,
+          "vendor_contact_person": {},
+          "payment_method": {
+            "value": "CREDITCARD",
+            "desc": "Credit card"
+          },
+          "reference_number": "",
+          "additional_charges": {
+            "use_pro_rata": false,
+            "shipment": 0,
+            "overhead": 0,
+            "insurance": 0,
+            "discount": 0
+          },
+          "invoice_vat": {
+            "report_tax": false,
+            "vat_per_invoice_line": false,
+            "vat_code": {
+              "value": "",
+              "desc": null
+            },
+            "percentage": 0,
+            "vat_amount": 0,
+            "type": {
+              "value": "INCLUSIVE",
+              "desc": "Inclusive"
+            },
+            "expended_from_fund": false
+          },
+          "explicit_ratio": [],
+          "payment": {
+            "prepaid": false,
+            "internal_copy": false,
+            "payment_status": {
+              "value": "NOT_PAID",
+              "desc": "Not Paid"
+            },
+            "voucher_date": "2022-01-12Z",
+            "voucher_number": "",
+            "voucher_amount": "0",
+            "voucher_currency": {
+              "value": "USD",
+              "desc": "US Dollar"
+            }
+          }
+        },
+        "invoice_lines": [
+          {
+            "type": {
+              "value": "REGULAR",
+              "desc": "Regular"
+            },
+            "number": "1",
+            "price": 100,
+            "total_price": 100,
+            "quantity": 1,
+            "fund_distribution": [
+              {
+                "fund_code": {
+                  "value": "C-IRC-HCAT",
+                  "desc": "Onsite Cataloging"
+                },
+                "amount": 100
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "Serials invoice paid via SAP",
+        "post_json": {
+          "vendor": {
+            "value": "TestSAPVendor2-S",
+            "desc": "Test SAP Vendor 2 Serials"
+          },
+          "owner": {
+            "value": "01MIT_INST",
+            "desc": "Massachusetts Institute of Technology"
+          },
+          "invoice_date": "2022-01-12Z",
+          "total_amount": 100,
+          "currency": {
+            "value": "USD",
+            "desc": "US Dollar"
+          },
+          "total_invoice_lines_amount": 100,
+          "vendor_contact_person": {},
+          "payment_method": {
+            "value": "ACCOUNTINGDEPARTMENT",
+            "desc": "Accounting Department"
+          },
+          "reference_number": "",
+          "additional_charges": {
+            "use_pro_rata": false,
+            "shipment": 0,
+            "overhead": 0,
+            "insurance": 0,
+            "discount": 0
+          },
+          "invoice_vat": {
+            "report_tax": false,
+            "vat_per_invoice_line": false,
+            "vat_code": {
+              "value": "",
+              "desc": null
+            },
+            "percentage": 0,
+            "vat_amount": 0,
+            "type": {
+              "value": "INCLUSIVE",
+              "desc": "Inclusive"
+            },
+            "expended_from_fund": false
+          },
+          "explicit_ratio": [],
+          "payment": {
+            "prepaid": false,
+            "internal_copy": false,
+            "payment_status": {
+              "value": "NOT_PAID",
+              "desc": "Not Paid"
+            },
+            "voucher_date": "2022-01-12Z",
+            "voucher_number": "",
+            "voucher_amount": "0",
+            "voucher_currency": {
+              "value": "USD",
+              "desc": "US Dollar"
+            }
+          }
+        },
+        "invoice_lines": [
+          {
+            "type": {
+              "value": "REGULAR",
+              "desc": "Regular"
+            },
+            "number": "1",
+            "price": 100,
+            "total_price": 100,
+            "quantity": 1,
+            "fund_distribution": [
+              {
+                "fund_code": {
+                  "value": "C-IRC-HCAT",
+                  "desc": "Onsite Cataloging"
+                },
+                "amount": 100
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/invoice_line.json
+++ b/tests/fixtures/invoice_line.json
@@ -1,0 +1,34 @@
+{"type": {
+    "id": "5678910",
+    "value": "REGULAR"
+    },
+    "number": "1",
+    "price": 100.0,
+    "price_note": "",
+    "total_price": 100,
+    "quantity": 1,
+    "vat_note": "Approximately 0.00 included in VAT/GST adjustment line.",
+    "check_subscription_date_overlap": true,
+    "fully_invoiced": false,
+    "additional_info": "",
+    "release_remaining_encumbrance": false,
+    "note": "",
+    "invoice_line_vat": {
+        "vat_code": {
+            "value": "",
+            "desc": null
+        },
+        "percentage": 0.0,
+        "vat_amount": 0
+    },
+    "fund_distribution": [
+        {
+            "fund_code": {
+                "value": "FOO FUND",
+                "desc": "this is the foo fund"
+            },
+            "percent": null,
+            "amount": 100
+        }
+    ]
+}

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from llama import CONFIG
 from llama.alma import Alma_API_Client
@@ -26,6 +27,29 @@ def test_alma_set_content_headers():
     assert client.headers["Content-Type"] == "application/json"
 
 
+def test_alma_create_invoice(mocked_alma, mocked_alma_api_client):
+    with open("tests/fixtures/invoices.json") as f:
+        invoice_data = json.load(f)["invoice"][0]
+    invoice = mocked_alma_api_client.create_invoice(invoice_data)
+    assert invoice["id"] == "01"
+
+
+def test_alma_create_invoice_line(mocked_alma, mocked_alma_api_client):
+    with open("tests/fixtures/invoice_line.json") as f:
+        invoice_line_data = json.load(f)
+    invoice_line = mocked_alma_api_client.create_invoice_line(
+        "123456789", invoice_line_data
+    )
+    assert invoice_line["number"] == "1"
+
+
+def test_alma_create_vendor(mocked_alma, mocked_alma_api_client):
+    with open("tests/fixtures/vendor.json") as f:
+        vendor_data = json.load(f)
+    vendor = mocked_alma_api_client.create_vendor(vendor_data)
+    assert vendor["code"] == "BKHS"
+
+
 def test_alma_get_brief_po_lines(mocked_alma, mocked_alma_api_client):
     po_line_stubs = mocked_alma_api_client.get_brief_po_lines()
     assert next(po_line_stubs) == {"created_date": "2021-05-13Z", "number": "POL-123"}
@@ -47,6 +71,11 @@ def test_alma_get_vendor_details(mocked_alma, mocked_alma_api_client):
     vendor = mocked_alma_api_client.get_vendor_details("BKHS")
     assert vendor["code"] == "BKHS"
     assert vendor["name"] == "The Bookhouse, Inc."
+
+
+def test_alma_get_vendor_invoices(mocked_alma, mocked_alma_api_client):
+    invoices = mocked_alma_api_client.get_vendor_invoices("BKHS")
+    assert len(list(invoices)) == 3
 
 
 def test_alma_get_po_line_full_record(mocked_alma, mocked_alma_api_client):
@@ -84,3 +113,8 @@ def test_alma_get_paged(mocked_alma, mocked_alma_api_client):
         limit=10,
     )
     assert len(list(records)) == 15
+
+
+def test_alma_process_invoice(mocked_alma, mocked_alma_api_client):
+    processed_invoice = mocked_alma_api_client.process_invoice("00000055555000000")
+    assert processed_invoice["invoice_workflow_status"]["value"] == "Waiting to be Sent"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,6 +154,11 @@ def test_concat_timdex_export_bucket_error(mocked_s3, runner):
     assert "One or more supplied buckets does not exist" in result.output
 
 
+def test_create_sandbox_sap_data(mocked_alma_sample_data, runner):
+    result = runner.invoke(cli, ["create-sandbox-sap-data"])
+    assert result.exit_code == 0
+
+
 def test_sap_invoices_review_run(runner, mocked_alma, mocked_ses):
     result = runner.invoke(cli, ["sap-invoices"])
     assert result.exit_code == 0

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -1,0 +1,139 @@
+import json
+
+import pytest
+from requests.exceptions import HTTPError
+
+from llama import sample_data as sd
+
+
+def test_load_sample_data(mocked_alma_sample_data, mocked_alma_api_client):
+    with open("sample-data/sample-sap-invoice-data.json") as f:
+        contents = json.load(f)
+    result = sd.load_sample_data(mocked_alma_api_client, contents)
+    assert result == 4
+
+
+def test_create_vendor_if_needed_creates_vendor(
+    caplog, mocked_alma_sample_data, mocked_alma_api_client
+):
+    result = sd.create_vendor_if_needed(
+        mocked_alma_api_client, {"code": "TestSAPVendor1"}
+    )
+    assert result == "TestSAPVendor1"
+    assert "Vendor 'TestSAPVendor1' created in Alma" in caplog.text
+
+
+def test_create_vendor_if_needed_vendor_exists(
+    caplog, mocked_alma_sample_data, mocked_alma_api_client
+):
+    result = sd.create_vendor_if_needed(
+        mocked_alma_api_client, {"code": "TestSAPVendor2-S"}
+    )
+    assert result == "TestSAPVendor2-S"
+    assert (
+        "Vendor 'TestSAPVendor2-S' already exists in Alma, not creating it"
+        in caplog.text
+    )
+
+
+def test_create_vendor_if_needed_raises_exception(
+    caplog, mocked_alma_sample_data, mocked_alma_api_client
+):
+    with pytest.raises(HTTPError):
+        sd.create_vendor_if_needed(mocked_alma_api_client, {"code": "not-a-vendor"})
+    assert '{"errorCode":"a-different-error"}' in caplog.text
+
+
+def test_get_next_vendor_invoice_number_existing_invoices(
+    mocked_alma_sample_data, mocked_alma_api_client
+):
+    result = sd.get_next_vendor_invoice_number(mocked_alma_api_client, "TestSAPVendor1")
+    assert result == 3
+
+
+def test_get_next_vendor_invoice_number_no_existing_invoices(
+    mocked_alma_sample_data, mocked_alma_api_client
+):
+    result = sd.get_next_vendor_invoice_number(
+        mocked_alma_api_client, "TestSAPVendor2-S"
+    )
+    assert result == 1
+
+
+def test_get_next_vendor_invoice_number_nonconforming_numbers_exist(
+    mocked_alma_sample_data, mocked_alma_api_client
+):
+    result = sd.get_next_vendor_invoice_number(mocked_alma_api_client, "TestSAPVendor3")
+    assert result == 1
+
+
+def test_create_invoices_with_lines(
+    caplog, mocked_alma_sample_data, mocked_alma_api_client
+):
+    invoices = [
+        {"post_json": {}, "invoice_lines": [{"line1": "contents"}]},
+        {
+            "post_json": {},
+            "invoice_lines": [{"line1": "contents"}, {"line2": "contents"}],
+        },
+    ]
+    result = sd.create_invoices_with_lines(mocked_alma_api_client, invoices, "V1", 1)
+    assert result == ["alma_id_0001", "alma_id_0002"]
+    assert "Created invoice 'TestSAPInvoiceV1-2' with 2 lines" in caplog.text
+
+
+def test_create_invoice(caplog, mocked_alma_sample_data, mocked_alma_api_client):
+    result = sd.create_invoice(mocked_alma_api_client, {"invoice": "has some data"})
+    assert result == "alma_id_0001"
+    assert 'Invoice created with data: {"id": "alma_id_0001"}' in caplog.text
+
+
+def test_create_invoice_raises_error(
+    caplog, mocked_alma_with_errors, mocked_alma_api_client
+):
+    with pytest.raises(HTTPError):
+        sd.create_invoice(mocked_alma_api_client, {"invoice": "has some data"})
+    assert "Error message" in caplog.text
+
+
+def test_create_invoice_lines(caplog, mocked_alma_sample_data, mocked_alma_api_client):
+    invoice_lines = [
+        {"line1": "line 1 contents"},
+        {"line2": "line 2 contents"},
+    ]
+    result = sd.create_invoice_lines(
+        mocked_alma_api_client, "alma_id_0001", invoice_lines
+    )
+    assert result == 2
+    assert (
+        "Invoice line created for invoice 'alma_id_0001' with data: "
+        '{"id": "alma_id_0001"}' in caplog.text
+    )
+
+
+def test_create_invoice_lines_raises_exception(
+    caplog, mocked_alma_sample_data, mocked_alma_api_client
+):
+    with pytest.raises(HTTPError):
+        sd.create_invoice_lines(
+            mocked_alma_api_client, "error_id", [{"invoice_lines": "line"}]
+        )
+    assert "Error message" in caplog.text
+
+
+def test_process_invoices(caplog, mocked_alma_sample_data, mocked_alma_api_client):
+    invoice_ids = ["alma_id_0001", "alma_id_0002", "alma_id_0003", "alma_id_0004"]
+    result = sd.process_invoices(mocked_alma_api_client, invoice_ids)
+    assert result == 4
+    assert (
+        "Invoice 'alma_id_0004' processed in Alma with response: "
+        '{"id": "alma_id_0004"}' in caplog.text
+    )
+
+
+def test_process_invoices_raises_exception(
+    caplog, mocked_alma_sample_data, mocked_alma_api_client
+):
+    with pytest.raises(HTTPError):
+        sd.process_invoices(mocked_alma_api_client, ["error_id"])
+    assert "Error message" in caplog.text


### PR DESCRIPTION
#### What does this PR do?
* Adds a CLI command to create sandbox sap data
* Adds a sample_data module with the functionality needed to get or create vendors, create invoices, and create invoice lines
* Adds methods to the Alma_API_Client class for new API calls used by this feature
* Adds tests for all new functions, updates conftest and pytest.ini
* Update README to include instructions for creating sample data and then manually approving it in the Alma sandbox UI.

#### Helpful background context
Running the sap-invoices command during development or staging runs requires there to be sample invoices in the sandbox that are ready to be paid. Rather than asking stakeholders to create sample invoices every time we need them or doing the entire creation manually ourselves, this automates at least the initial steps of creation, using consistent and repeatable data.

#### How can a reviewer manually see the effects of these changes?
Please use the instructions in the README to run this process locally and ensure it works (this will also verify that the instructions are accurate and make sense!)

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/ASI-35

#### Includes new or updated dependencies?
NO

#### Changes expectations for external applications?
NO

#### Developer
- [x] All new config values are documented in README
- [x] All new config values have been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
