### PR TITLE
Correct mapping to cost object and G/L account

### DIFF
--- a/llama/sap.py
+++ b/llama/sap.py
@@ -185,8 +185,8 @@ def populate_fund_data(
             except KeyError:
                 fund_data[external_id] = {
                     "amount": amount,
-                    "G/L account": external_id.split("-")[0],
-                    "cost object": external_id.split("-")[1],
+                    "cost object": external_id.split("-")[0],
+                    "G/L account": external_id.split("-")[1],
                 }
             invoice_lines_total += amount
     fund_data = collections.OrderedDict(sorted(fund_data.items()))
@@ -247,8 +247,8 @@ def generate_report(today: datetime, invoices: List[dict]) -> str:
         for fund in invoice["funds"]:
             report += f"{invoice['number'] + invoice['date'].strftime('%y%m%d'):<23}"
             report += (
-                f"{invoice['funds'][fund]['G/L account']} "
-                f"{invoice['funds'][fund]['cost object']}     "
+                f"{invoice['funds'][fund]['cost object']} "
+                f"{invoice['funds'][fund]['G/L account']}     "
             )
             report += f"{invoice['funds'][fund]['amount']:<18,.2f}"
             report += f"{invoice['date'].strftime('%m/%d/%Y')}\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -508,8 +508,8 @@ def invoices_for_sap():
             "funds": {
                 "123456-0000001": {
                     "amount": 150,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
+                    "cost object": "123456",
+                    "G/L account": "0000001",
                 },
             },
         },
@@ -537,23 +537,23 @@ def invoices_for_sap():
             "funds": {
                 "123456-0000001": {
                     "amount": 608,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
+                    "cost object": "123456",
+                    "G/L account": "0000001",
                 },
                 "123456-0000002": {
                     "amount": 148.50,
-                    "G/L account": "123456",
-                    "cost object": "0000002",
+                    "cost object": "123456",
+                    "G/L account": "0000002",
                 },
                 "1123456-0000003": {
                     "amount": 235.54,
-                    "G/L account": "123456",
-                    "cost object": "0000003",
+                    "cost object": "123456",
+                    "G/L account": "0000003",
                 },
                 "123456-0000004": {
                     "amount": 75,
-                    "G/L account": "123456",
-                    "cost object": "0000004",
+                    "cost object": "123456",
+                    "G/L account": "0000004",
                 },
             },
         },
@@ -581,8 +581,8 @@ def invoices_for_sap():
             "funds": {
                 "123456-0000001": {
                     "amount": 150,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
+                    "cost object": "123456",
+                    "G/L account": "0000001",
                 },
             },
         },
@@ -621,8 +621,8 @@ def invoices_for_sap_with_different_payment_method():
             "funds": {
                 "123456-0000001": {
                     "amount": 150,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
+                    "cost object": "123456",
+                    "G/L account": "0000001",
                 },
             },
         },
@@ -650,23 +650,23 @@ def invoices_for_sap_with_different_payment_method():
             "funds": {
                 "123456-0000001": {
                     "amount": 608,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
+                    "cost object": "123456",
+                    "G/L account": "0000001",
                 },
                 "123456-0000002": {
                     "amount": 148.50,
-                    "G/L account": "123456",
-                    "cost object": "0000002",
+                    "cost object": "123456",
+                    "G/L account": "0000002",
                 },
                 "1123456-0000003": {
                     "amount": 235.54,
-                    "G/L account": "123456",
-                    "cost object": "0000003",
+                    "cost object": "123456",
+                    "G/L account": "0000003",
                 },
                 "123456-0000004": {
                     "amount": 75,
-                    "G/L account": "123456",
-                    "cost object": "0000004",
+                    "cost object": "123456",
+                    "G/L account": "0000004",
                 },
             },
         },
@@ -694,8 +694,8 @@ def invoices_for_sap_with_different_payment_method():
             "funds": {
                 "123456-0000001": {
                     "amount": 150,
-                    "G/L account": "123456",
-                    "cost object": "0000001",
+                    "cost object": "123456",
+                    "G/L account": "0000001",
                 },
             },
         },
@@ -735,8 +735,8 @@ US \
                                    \
 \n\
 D\
-123456    \
-0000001     \
+0000001   \
+123456      \
           150.00\
  \
 \n\
@@ -765,26 +765,26 @@ US \
                                    \
 \n\
 C\
-123456    \
-0000001     \
+0000001   \
+123456      \
           608.00\
  \
 \n\
 C\
-123456    \
-0000002     \
+0000002   \
+123456      \
           148.50\
  \
 \n\
 C\
-123456    \
-0000003     \
+0000003   \
+123456      \
           235.54\
  \
 \n\
 D\
-123456    \
-0000004     \
+0000004   \
+123456      \
            75.00\
  \
 \n\
@@ -813,8 +813,8 @@ US \
                                    \
 \n\
 D\
-123456    \
-0000001     \
+0000001   \
+123456      \
           150.00\
  \
 \n"

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -172,18 +172,18 @@ def test_populate_fund_data_success(mocked_alma, mocked_alma_api_client):
     fund_data_ordereddict = collections.OrderedDict()
     fund_data_ordereddict["1234567-000001"] = {
         "amount": 3687.32,
-        "G/L account": "1234567",
-        "cost object": "000001",
+        "cost object": "1234567",
+        "G/L account": "000001",
     }
     fund_data_ordereddict["1234567-000002"] = {
         "amount": 299,
-        "G/L account": "1234567",
-        "cost object": "000002",
+        "cost object": "1234567",
+        "G/L account": "000002",
     }
     fund_data_ordereddict["1234567-000003"] = {
         "amount": 69.75,
-        "G/L account": "1234567",
-        "cost object": "000003",
+        "cost object": "1234567",
+        "G/L account": "000003",
     }
 
     assert fund_data == fund_data_ordereddict
@@ -219,18 +219,18 @@ def test_generate_report_success():
             "funds": {
                 "1234567-000001": {
                     "amount": 3687.32,
-                    "G/L account": "1234567",
-                    "cost object": "000001",
+                    "cost object": "1234567",
+                    "G/L account": "000001",
                 },
                 "1234567-000002": {
                     "amount": 299,
-                    "G/L account": "1234567",
-                    "cost object": "000002",
+                    "cost object": "1234567",
+                    "G/L account": "000002",
                 },
                 "1234567-000003": {
                     "amount": 69.75,
-                    "G/L account": "1234567",
-                    "cost object": "000003",
+                    "cost object": "1234567",
+                    "G/L account": "000003",
                 },
             },
         }


### PR DESCRIPTION
Why these changes are being introduced:
The cost object and G/L account were incorrectly mapped from the API data.
Because of this these fields were in the wrong order in the SAP data file, leading
to that file being rejected when it was submitted.

How this addresses that need:
* corrects mapping from alma data
* updates tests and fixture data with the correct names
* updates reports so these fields remain in the
expected positions

Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ASI-44


