### PR TITLE
fix rounding errors in total amount calculation

### DIFF
--- a/llama/sap.py
+++ b/llama/sap.py
@@ -4,6 +4,7 @@ import collections
 import json
 import logging
 from datetime import datetime
+from math import fsum
 from typing import List, Literal, Optional, Tuple
 
 from llama import CONFIG
@@ -495,8 +496,7 @@ def update_sap_sequence(
 
 def calculate_invoices_total_amount(invoices: List[dict]) -> float:
     total_amount = 0
-    for invoice in invoices:
-        total_amount += float(invoice["total amount"])
+    total_amount = fsum([invoice["total amount"] for invoice in invoices])
     return total_amount
 
 

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -382,6 +382,12 @@ def test_generate_sap_data_success(invoices_for_sap, sap_data_file):
     assert report == sap_data_file
 
 
+def test_calculate_invoices_total_amount():
+    invoices = [dict(zip(["total amount"], [0.1])) for x in range(100)]
+    total_amount = sap.calculate_invoices_total_amount(invoices)
+    assert total_amount == 10
+
+
 def test_generate_summary(invoices_for_sap_with_different_payment_method):
     dfile = "dlibsapg.1001.202110518000000"
     cfile = "clibsapg.1001.202110518000000"


### PR DESCRIPTION
# Why these changes are being introduced:
* the way we were calculating the total amount for the control file
 led to rounding errors in some cases

# How this addresses that need:
* uses fsum() to return an accurate sum of total amounts for the control file

# Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ES-705

#### What does this PR do?
This fixes an issue where the calculation of the sum of the total amounts of invoices
could result in a rounding error.

#### Includes new or updated dependencies?

NO, unless importing fsum() from the math module counts as a dependency.

#### Changes expectations for external applications?

NO

#### Developer

- [ ] All new config values are documented in README
- [ ] All new config values have been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
