### PR TITLE
treat all addresses as street addresses

### DIFF
--- a/llama/sap.py
+++ b/llama/sap.py
@@ -303,47 +303,23 @@ def generate_sap_report_email(
 
 def format_address_for_sap(address_lines: List):
     """Assign payee address information to SAP data file fields"""
-    street_or_po_box_num = " "
-    po_box_indicator = " "
-    po_index = -1
-    # Determine if this is a P.O. Box address or a street address
-    for i, line in enumerate(address_lines):
-        normalized_line = line.lower().replace(".", "").replace(" ", "")
-        if "pobox" in normalized_line:
-            po_box_indicator = "X"
-            street_or_po_box_num = normalized_line.replace("pobox", "")
-            po_index = i
-    # If the PO box was found in the first element in the address lines list, then
-    # make the payee_name_line_2 blank
-    if po_index == 0:
-        payee_name_line_2 = " "
 
-    # If the PO box was found in the second address lines element, then
-    # assign the first address lines element to the payee_name_line_2
-    elif po_index == 1:
-        payee_name_line_2 = address_lines[0]
+    payee_name_line_2 = address_lines[0]
 
-    # we didn't find "pobox" so this must be a street address
-    # SAP doesn't support multiple address lines, so we assign the first address
-    # line to the payee_name_line_2 field.
-    else:
-        payee_name_line_2 = address_lines[0]
+    # if there is a second address line element we
+    # assign it to the street_or_po_box_num field
+    try:
+        street_or_po_box_num = address_lines[1]
+    except IndexError:
+        street_or_po_box_num = " "
 
-        # if there is a second address line element we
-        # assign it to the street_or_po_box_num field
-        try:
-            street_or_po_box_num = address_lines[1]
-        except IndexError:
-            street_or_po_box_num = " "
-
-    # regardless of whether it was a PO box or street address
     # if there is a third address lines list element we assign it to payee_name_line_3
     try:
         payee_name_line_3 = address_lines[2]
     except IndexError:
         payee_name_line_3 = " "
 
-    return po_box_indicator, payee_name_line_2, street_or_po_box_num, payee_name_line_3
+    return payee_name_line_2, street_or_po_box_num, payee_name_line_3
 
 
 def generate_sap_data(today: datetime, invoices: List[dict]) -> str:
@@ -355,7 +331,6 @@ def generate_sap_data(today: datetime, invoices: List[dict]) -> str:
     sap_data = ""
     for invoice in invoices:
         (
-            po_box_indicator,
             payee_name_line_2,
             street_or_po_box_num,
             payee_name_line_3,
@@ -381,7 +356,9 @@ def generate_sap_data(today: datetime, invoices: List[dict]) -> str:
         sap_data += f"{invoice['vendor']['name']: <35.35}"
         sap_data += f"{invoice['vendor']['address']['city'] or ' ': <35.35}"
         sap_data += f"{payee_name_line_2: <35.35}"
-        sap_data += po_box_indicator
+        # We treat all addresses as street addresses.
+        # PO Box indicator should always be blank.
+        sap_data += " "  # PO Box indicator
         sap_data += f"{street_or_po_box_num: <35.35}"
         sap_data += f"{invoice['vendor']['address']['postal code'] or ' ': <10.10}"
         sap_data += f"{invoice['vendor']['address']['state or province'] or ' ': <3.3}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -755,9 +755,9 @@ X000\
 X\
 some library solutions from salad  \
 Atlanta                            \
+P.O. Box 123456                    \
+ \
                                    \
-X\
-123456                             \
 30384-7991\
 GA \
 US \

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -309,12 +309,10 @@ def test_generate_sap_report_email_review_run():
 def test_format_address_street_1_line():
     address_lines = ["123 salad Street"]
     (
-        po_box_indicator,
         payee_name_line_2,
         street_or_po_box_num,
         payee_name_line_3,
     ) = sap.format_address_for_sap(address_lines)
-    assert po_box_indicator == " "
     assert payee_name_line_2 == address_lines[0]
     assert street_or_po_box_num == " "
     assert payee_name_line_3 == " "
@@ -323,12 +321,10 @@ def test_format_address_street_1_line():
 def test_format_address_street_2_lines():
     address_lines = ["123 salad Street", "Second Floor"]
     (
-        po_box_indicator,
         payee_name_line_2,
         street_or_po_box_num,
         payee_name_line_3,
     ) = sap.format_address_for_sap(address_lines)
-    assert po_box_indicator == " "
     assert payee_name_line_2 == address_lines[0]
     assert street_or_po_box_num == address_lines[1]
     assert payee_name_line_3 == " "
@@ -337,12 +333,10 @@ def test_format_address_street_2_lines():
 def test_format_address_street_3_lines():
     address_lines = ["123 salad Street", "Second Floor", "c/o salad guy"]
     (
-        po_box_indicator,
         payee_name_line_2,
         street_or_po_box_num,
         payee_name_line_3,
     ) = sap.format_address_for_sap(address_lines)
-    assert po_box_indicator == " "
     assert payee_name_line_2 == address_lines[0]
     assert street_or_po_box_num == address_lines[1]
     assert payee_name_line_3 == address_lines[2]
@@ -351,28 +345,24 @@ def test_format_address_street_3_lines():
 def test_format_address_po_box_1_line():
     address_lines = ["P.O. Box 123456"]
     (
-        po_box_indicator,
         payee_name_line_2,
         street_or_po_box_num,
         payee_name_line_3,
     ) = sap.format_address_for_sap(address_lines)
-    assert po_box_indicator == "X"
-    assert payee_name_line_2 == " "
-    assert street_or_po_box_num == "123456"
+    assert payee_name_line_2 == address_lines[0]
+    assert street_or_po_box_num == " "
     assert payee_name_line_3 == " "
 
 
 def test_format_address_po_box_2_lines():
     address_lines = ["c/o salad guy", "P.O. Box 123456"]
     (
-        po_box_indicator,
         payee_name_line_2,
         street_or_po_box_num,
         payee_name_line_3,
     ) = sap.format_address_for_sap(address_lines)
-    assert po_box_indicator == "X"
     assert payee_name_line_2 == address_lines[0]
-    assert street_or_po_box_num == "123456"
+    assert street_or_po_box_num == address_lines[1]
     assert payee_name_line_3 == " "
 
 


### PR DESCRIPTION
# Why these changes are being introduced:
An incorrectly formatted PO Box address in Alma resulted in an error in SAP
After consultation with Accounts Payable it was determined that we could treat all
addresses as street address, which should prevent this error from happening in the future
and will simplify the code that formats address information for data files

# How this addresses that need:
* removes code which set the PO address indicator in the datafile
* updates code to consistently map address lines to datafile fields
* updates tests

# Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ES-722

