### PR TITLE
fixes bug in control file generation function

### DIFF
--- a/llama/sap.py
+++ b/llama/sap.py
@@ -464,11 +464,11 @@ def generate_sap_control(sap_data_file: str, invoice_total: float) -> str:
     # 53-72 debit total - convert invoice total to string
     # remove decimal to convert dollars to cents
     # and 0-pad to 20 characters
-    sap_control_file += f"{str(invoice_total).replace('.', ''):0>20}"
+    sap_control_file += f"{'{:.2f}'.format(invoice_total).replace('.', ''):0>20}"
 
     # 73-92 control 3 summarizing the data file
     # we just repeat the invoice total here
-    sap_control_file += f"{str(invoice_total).replace('.', ''):0>20}"
+    sap_control_file += f"{'{:.2f}'.format(invoice_total).replace('.', ''):0>20}"
 
     # 93-112 control 4 summarizing the data file
     # Accounts payable told us to use this string

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -418,13 +418,13 @@ BAZ:\t12345\tFoo Bar Books\tFOOBAR
 
 
 def test_generate_sap_control(sap_data_file):
-    invoice_total = 1367.04
+    invoice_total = 1367.40
     sap_control = sap.generate_sap_control(sap_data_file, invoice_total)
     assert sap_control[0:16] == "0000000000001182"
     assert sap_control[16:32] == "0000000000000009"
     assert sap_control[32:52] == "00000000000000000000"
-    assert sap_control[52:72] == "00000000000000136704"
-    assert sap_control[72:92] == "00000000000000136704"
+    assert sap_control[52:72] == "00000000000000136740"
+    assert sap_control[72:92] == "00000000000000136740"
     assert sap_control[92:112] == "00100100000000000000"
     assert len(sap_control.encode("utf-8")) == 113
 


### PR DESCRIPTION
when an invoice total was a decimal ending in 0, the 0 wasn't
being included in the string to which we converted the float

this specifies that the float should be formatted as a
string with two decimal places

Updates the test for this function to have an invoice total with
a decimal ending in a 0


#### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/ES-763

#### Includes new or updated dependencies?

YES | NO

#### Changes expectations for external applications?

YES | NO

#### Developer

- [ ] All new config values are documented in README
- [ ] All new config values have been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
