### PR TITLE
Handles fund errors and multibyte character errors

### DIFF
--- a/llama/cli.py
+++ b/llama/cli.py
@@ -199,6 +199,7 @@ def sap_invoices(ctx, final_run, real_run):
     problem_invoices, parsed_invoices = sap.parse_invoice_records(
         alma_client, invoice_records
     )
+    logger.info(f"{len(problem_invoices)} problem invoices found.")
 
     # Split invoices into monographs and serials
     monograph_invoices, serial_invoices = sap.split_invoices_by_field_value(

--- a/llama/cli.py
+++ b/llama/cli.py
@@ -196,7 +196,9 @@ def sap_invoices(ctx, final_run, real_run):
         raise click.Abort()
 
     # Parse retrieved invoices and extract data needed for SAP
-    parsed_invoices = sap.parse_invoice_records(alma_client, invoice_records)
+    problem_invoices, parsed_invoices = sap.parse_invoice_records(
+        alma_client, invoice_records
+    )
 
     # Split invoices into monographs and serials
     monograph_invoices, serial_invoices = sap.split_invoices_by_field_value(
@@ -209,6 +211,7 @@ def sap_invoices(ctx, final_run, real_run):
     monograph_sequence_number = sap.generate_next_sap_sequence_number()
     serial_sequence_number = str(int(monograph_sequence_number) + 1)
     monograph_result = sap.run(
+        problem_invoices,
         monograph_invoices,
         "monograph",
         monograph_sequence_number,
@@ -217,6 +220,7 @@ def sap_invoices(ctx, final_run, real_run):
         real_run,
     )
     serial_result = sap.run(
+        problem_invoices,
         serial_invoices,
         "serial",
         serial_sequence_number,

--- a/llama/sap.py
+++ b/llama/sap.py
@@ -78,10 +78,9 @@ def parse_invoice_records(
             )
         except FundError as err:
             invoice_data["fund_errors"] = err.fund_codes
-        finally:
-            multibyte_errors = check_for_multibyte(invoice_data)
-            if multibyte_errors:
-                invoice_data["multibyte_errors"] = multibyte_errors
+        multibyte_errors = check_for_multibyte(invoice_data)
+        if multibyte_errors:
+            invoice_data["multibyte_errors"] = multibyte_errors
         if ("multibyte_errors" in invoice_data) or ("fund_errors" in invoice_data):
             problem_invoices.append(invoice_data)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -604,7 +604,7 @@ def invoices_for_sap():
 def problem_invoices():
     problem_invoices = [
         {
-            "fund_errors": ["over-encumbred", "JKL"],
+            "fund_errors": ["over-encumbered", "also-over-encumbered"],
             "multibyte_errors": [
                 {"field": "vendor:address:lines:0", "character": "‑"},
                 {"field": "vendor:city", "character": "ƒ"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,10 @@ def mocked_alma(po_line_record_all_fields):
                 "http://example.com/acq/funds?q=fund_code~over-encumbered",
                 json={"total_record_count": 0},
             )
+            m.get(
+                "http://example.com/acq/funds?q=fund_code~also-over-encumbered",
+                json={"total_record_count": 0},
+            )
 
         # Invoice endpoints
         with open("tests/fixtures/invoices.json") as f:
@@ -598,92 +602,60 @@ def invoices_for_sap():
 
 @pytest.fixture()
 def problem_invoices():
-    problem_invoices = {
-        "fund_errors": [
-            {
-                "problem_fund": "over-encumbred",
-                "date": datetime(2021, 5, 12),
-                "id": "9991",
-                "number": "456789",
-                "type": "monograph",
-                "payment method": "ACCOUNTINGDEPARTMENT",
-                "total amount": 150,
-                "currency": "USD",
-                "vendor": {
-                    "name": "Danger Inc.",
-                    "code": "FOOBAR-M",
-                    "address": {
-                        "lines": [
-                            "123 salad Street",
-                            "Second Floor",
-                        ],
-                        "city": "San Francisco",
-                        "state or province": "CA",
-                        "postal code": "94109",
-                        "country": "US",
-                    },
+    problem_invoices = [
+        {
+            "fund_errors": ["over-encumbred", "JKL"],
+            "multibyte_errors": [
+                {"field": "vendor:address:lines:0", "character": "‑"},
+                {"field": "vendor:city", "character": "ƒ"},
+            ],
+            "date": datetime(2021, 5, 12),
+            "id": "9991",
+            "number": "456789",
+            "type": "monograph",
+            "payment method": "ACCOUNTINGDEPARTMENT",
+            "total amount": 150,
+            "currency": "USD",
+            "vendor": {
+                "name": "Danger Inc.",
+                "code": "FOOBAR-M",
+                "address": {
+                    "lines": [
+                        "12‑3 salad Street",
+                        "Second Floor",
+                    ],
+                    "city": "San ƒrancisco",
+                    "state or province": "CA",
+                    "postal code": "94109",
+                    "country": "US",
                 },
             },
-            {
-                "problem_fund": "over-encumbred",
-                "date": datetime(2021, 5, 11),
-                "id": "9992",
-                "number": "444555",
-                "type": "monograph",
-                "payment method": "ACCOUNTINGDEPARTMENT",
-                "total amount": 1067.04,
-                "currency": "USD",
-                "vendor": {
-                    "name": "some library solutions from salad",
-                    "code": "YBPE-M",
-                    "address": {
-                        "lines": [
-                            "P.O. Box 123456",
-                        ],
-                        "city": "Atlanta",
-                        "state or province": "GA",
-                        "postal code": "30384-7991",
-                        "country": "US",
-                    },
+        },
+        {
+            "fund_errors": ["also-over-encumbered"],
+            "multibyte_errors": [{"field": "vendor:address:lines:0", "character": "‑"}],
+            "date": datetime(2021, 5, 11),
+            "id": "9992",
+            "number": "444555",
+            "type": "monograph",
+            "payment method": "ACCOUNTINGDEPARTMENT",
+            "total amount": 1067.04,
+            "currency": "USD",
+            "vendor": {
+                "name": "some library solutions from salad",
+                "code": "YBPE-M",
+                "address": {
+                    "lines": [
+                        "P.O. Box 123456",
+                    ],
+                    "city": "Atlanta",
+                    "state or province": "GA",
+                    "postal code": "30384‑7991",
+                    "country": "US",
                 },
             },
-        ],
-        "multibyte_errors": [
-            {
-                "multibyte_locations": [
-                    {"field": "vendor:address:lines:0", "character": "‑"},
-                    {"field": "vendor:city", "character": "ƒ"},
-                ],
-                "date": datetime(2021, 5, 12),
-                "id": "9993",
-                "number": "456789",
-                "type": "monograph",
-                "payment method": "ACCOUNTINGDEPARTMENT",
-                "total amount": 150,
-                "currency": "USD",
-                "vendor": {
-                    "name": "one address line",
-                    "code": "FOOBAR-M",
-                    "address": {
-                        "lines": [
-                            "12‑3 some street",
-                        ],
-                        "city": "San ƒrancisco",
-                        "state or province": "CA",
-                        "postal code": "94109",
-                        "country": "US",
-                    },
-                },
-                "funds": {
-                    "123456-0000001": {
-                        "amount": 150,
-                        "cost object": "123456",
-                        "G/L account": "0000001",
-                    }
-                },
-            }
-        ],
-    }
+        },
+    ]
     return problem_invoices
 
 

--- a/tests/fixtures/invoice_with_over_encumbrance.json
+++ b/tests/fixtures/invoice_with_over_encumbrance.json
@@ -1,0 +1,159 @@
+{
+  "number": "123456",
+  "vendor": {
+    "value": "BKHS",
+    "desc": "The Bookhouse, Inc."
+  },
+  "owner": {
+    "value": "ACQ",
+    "desc": null
+  },
+  "id": "00000055555000000",
+  "invoice_date": "2021-09-27Z",
+  "total_amount": 4056.07,
+  "currency": {
+    "value": "USD",
+    "desc": "US Dollar"
+  },
+  "total_invoice_lines_amount": 4056.07,
+  "vendor_contact_person": {},
+  "payment_method": {
+    "value": "ACCOUNTINGDEPARTMENT",
+    "desc": "Accounting Department"
+  },
+  "reference_number": "",
+  "creation_form": {
+    "value": "EDI",
+    "desc": "EDIteur Invoice Message"
+  },
+  "invoice_status": {
+    "value": "ACTIVE",
+    "desc": "Active"
+  },
+  "invoice_workflow_status": {
+    "value": "Waiting to be Sent",
+    "desc": "Ready to be paid"
+  },
+  "invoice_approval_status": {
+    "value": "APPROVED",
+    "desc": "Approved"
+  },
+  "approved_by": "Smith Jane Q",
+  "approval_date": "2021-10-19Z",
+  "additional_charges": {
+    "use_pro_rata": true,
+    "shipment": 0.0,
+    "overhead": 0.0,
+    "insurance": 0.0,
+    "discount": 0.0
+  },
+  "invoice_vat": {
+    "report_tax": false,
+    "vat_per_invoice_line": false,
+    "vat_code": {
+      "value": "",
+      "desc": null
+    },
+    "percentage": 0.0,
+    "vat_amount": 0,
+    "type": {
+      "value": "LINEEXCLUSIVE",
+      "desc": "Line Exclusive"
+    },
+    "expended_from_fund": true
+  },
+  "explicit_ratio": [],
+  "payment": {
+    "prepaid": false,
+    "internal_copy": false,
+    "payment_status": {
+      "value": "NOT_PAID",
+      "desc": "Not Paid"
+    },
+    "voucher_date": "2021-09-30Z",
+    "voucher_number": "",
+    "voucher_amount": "",
+    "voucher_currency": {
+      "value": "",
+      "desc": null
+    }
+  },
+  "alert": [{
+    "value": "ADDITIONAL_INVOICE_EXISTS",
+    "desc": "Additional Invoice lines are linked to the same PO line"
+  }, {
+    "value": "DIFFERENT_VENDOR_ACCOUNT",
+    "desc": "Invoice holds vendor account different than some of the linked PO lines"
+  }, {
+    "value": "DIFF_PRICE_THAN_POLINE",
+    "desc": "Some invoice lines differ in price from their linked PO line."
+  }, {
+    "value": "EDI_INVOICE_OF_EXTERNAL_SYSTEM",
+    "desc": "The invoice was created by an external system and need to be reviewed."
+  }, {
+    "value": "NOT_LINKED_LINES",
+    "desc": "Lines not linked"
+  }],
+  "note": [],
+  "number_of_lines": {
+    "value": 1,
+    "link": "http://example.com/acq/invoices/00000055555000000/lines"
+  },
+  "invoice_lines": {
+    "invoice_line": [{
+      "id": "00000050015000000",
+      "type": {
+        "value": "REGULAR",
+        "desc": "Regular"
+      },
+      "number": "15",
+      "status": {
+        "value": "READY",
+        "desc": "Ready"
+      },
+      "po_line": "PK0015",
+      "price": 100.0,
+      "price_note": "",
+      "total_price": 100.0,
+      "quantity": 1,
+      "vat_note": "Approximately 0.00 included in line Total Price.",
+      "check_subscription_date_overlap": false,
+      "fully_invoiced": false,
+      "subscription_from_date": "2022-01-01Z",
+      "subscription_to_date": "2022-12-31Z",
+      "release_remaining_encumbrance": false,
+      "reporting_code": {
+        "value": "REPCODE",
+        "desc": "Subscription - SU (REPCODE)"
+      },
+      "secondary_reporting_code": {
+        "value": "",
+        "desc": null
+      },
+      "tertiary_reporting_code": {
+        "value": "",
+        "desc": null
+      },
+      "note": "Vol.85, No.1-4; 01.Jan.2022 - 31.Dec.2022\r\n ",
+      "invoice_line_vat": {
+        "vat_code": {
+          "value": "",
+          "desc": null
+        },
+        "percentage": 0.0,
+        "vat_amount": 0
+      },
+      "fund_distribution": [{
+        "fund_code": {
+          "value": "over-encumbered",
+          "desc": "over encumbered"
+        },
+        "percent": 100.0,
+        "amount": 100
+      }],
+      "link": "http://example.com/acq/invoices/00000055555000000/lines/00000050015000000"
+    }],
+    "total_record_count": 1
+  },
+  "link": "http://example.com/acq/invoices/00000055555000000"
+}

--- a/tests/fixtures/invoice_with_over_encumbrance.json
+++ b/tests/fixtures/invoice_with_over_encumbrance.json
@@ -106,7 +106,59 @@
         "value": "REGULAR",
         "desc": "Regular"
       },
-      "number": "15",
+      "number": "1",
+      "status": {
+        "value": "READY",
+        "desc": "Ready"
+      },
+      "po_line": "PK0015",
+      "price": 100.0,
+      "price_note": "",
+      "total_price": 100.0,
+      "quantity": 1,
+      "vat_note": "Approximately 0.00 included in line Total Price.",
+      "check_subscription_date_overlap": false,
+      "fully_invoiced": false,
+      "subscription_from_date": "2022-01-01Z",
+      "subscription_to_date": "2022-12-31Z",
+      "release_remaining_encumbrance": false,
+      "reporting_code": {
+        "value": "REPCODE",
+        "desc": "Subscription - SU (REPCODE)"
+      },
+      "secondary_reporting_code": {
+        "value": "",
+        "desc": null
+      },
+      "tertiary_reporting_code": {
+        "value": "",
+        "desc": null
+      },
+      "note": "Vol.85, No.1-4; 01.Jan.2022 - 31.Dec.2022\r\n ",
+      "invoice_line_vat": {
+        "vat_code": {
+          "value": "",
+          "desc": null
+        },
+        "percentage": 0.0,
+        "vat_amount": 0
+      },
+      "fund_distribution": [{
+        "fund_code": {
+          "value": "also-over-encumbered",
+          "desc": "also over encumbered"
+        },
+        "percent": 100.0,
+        "amount": 100
+      }],
+      "link": "http://example.com/acq/invoices/00000055555000000/lines/00000050015000000"
+    },{
+      "id": "00000050015000000",
+      "type": {
+        "value": "REGULAR",
+        "desc": "Regular"
+      },
+      "number": "2",
       "status": {
         "value": "READY",
         "desc": "Ready"
@@ -153,7 +205,7 @@
       }],
       "link": "http://example.com/acq/invoices/00000055555000000/lines/00000050015000000"
     }],
-    "total_record_count": 1
+    "total_record_count": 2
   },
   "link": "http://example.com/acq/invoices/00000055555000000"
 }

--- a/tests/fixtures/invoices.json
+++ b/tests/fixtures/invoices.json
@@ -1,5 +1,5 @@
 {
-  "total_record_count": 3,
+  "total_record_count": 5,
   "invoice": [
     {
       "id": "01",
@@ -348,6 +348,242 @@
               {
                 "fund_code": {
                   "value": "ABC"
+                },
+                "percent": 100,
+                "amount": -40.99
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "04",
+      "number": "0501130659",
+      "invoice_date": "2015-07-20Z",
+      "invoice_due_date": "2015-07-20",
+      "vendor": {
+        "value": "VEND-S"
+      },
+      "vendor_account": "ACCOUNT2",
+      "total_amount": 120,
+      "currency": {
+        "value": "USD"
+      },
+      "payment_method": {
+        "value": "CASH"
+      },
+      "reference_number": "5678",
+      "owner": {
+        "value": "LAW"
+      },
+      "additional_charges": {
+        "use_pro_rata": false,
+        "shipment": 0,
+        "overhead": 0,
+        "insurance": 0,
+        "discount": 0
+      },
+      "invoice_vat": {
+        "report_tax": false,
+        "vat_per_invoice_line": false,
+        "vat_code": {
+          "value": "REGULAR"
+        },
+        "percentage": 17,
+        "vat_amount": 17.44,
+        "type": {
+          "value": "INCLUSIVE"
+        },
+        "expended_from_fund": true,
+        "vendor_tax": "ILS"
+      },
+      "explicit_ratio": [
+        {
+          "foreign_currency": {
+            "value": "ILS"
+          },
+          "rate": 10
+        }
+      ],
+      "payment": {
+        "prepaid": false,
+        "internal_copy": false,
+        "export_to_erp": false,
+        "payment_status": {
+          "value": "PAID"
+        },
+        "voucher_date": "2015-07-20",
+        "voucher_number": "A-1234",
+        "voucher_amount": "120",
+        "voucher_currency": {
+          "value": "USD"
+        }
+      },
+      "notes": [
+        {
+          "note_text": "Created by: John Smith"
+        }
+      ],
+      "invoice_lines": {
+        "total_record_count": 999,
+        "invoice_line": [
+          {
+            "link": "string",
+            "type": {
+              "value": "REGULAR"
+            },
+            "number": "10",
+            "po_line": "20",
+            "price": 50,
+            "price_note": "string",
+            "quantity": 10,
+            "vat_note": "string",
+            "check_subscription_date_overlap": false,
+            "fully_invoiced": false,
+            "subscription_from_date": "2015-07-20",
+            "subscription_to_date": "2015-07-20",
+            "additional_info": "string",
+            "release_remaining_encumbrance": false,
+            "reporting_code": {
+              "value": "b"
+            },
+            "secondary_reporting_code": {
+              "value": "sso"
+            },
+            "tertiary_reporting_code": {
+              "value": "u"
+            },
+            "note": "string",
+            "invoice_line_vat": {
+              "vat_code": {
+                "value": "string"
+              },
+              "percentage": 0,
+              "vat_amount": 0
+            },
+            "fund_distribution": [
+              {
+                "fund_code": {
+                  "value": "over-encumbered"
+                },
+                "percent": 100,
+                "amount": -40.99
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "05",
+      "number": "0501130659",
+      "invoice_date": "2015-07-20Z",
+      "invoice_due_date": "2015-07-20",
+      "vendor": {
+        "value": "multibyte-address"
+      },
+      "vendor_account": "ACCOUNT2",
+      "total_amount": 120,
+      "currency": {
+        "value": "USD"
+      },
+      "payment_method": {
+        "value": "CASH"
+      },
+      "reference_number": "5678",
+      "owner": {
+        "value": "LAW"
+      },
+      "additional_charges": {
+        "use_pro_rata": false,
+        "shipment": 0,
+        "overhead": 0,
+        "insurance": 0,
+        "discount": 0
+      },
+      "invoice_vat": {
+        "report_tax": false,
+        "vat_per_invoice_line": false,
+        "vat_code": {
+          "value": "REGULAR"
+        },
+        "percentage": 17,
+        "vat_amount": 17.44,
+        "type": {
+          "value": "INCLUSIVE"
+        },
+        "expended_from_fund": true,
+        "vendor_tax": "ILS"
+      },
+      "explicit_ratio": [
+        {
+          "foreign_currency": {
+            "value": "ILS"
+          },
+          "rate": 10
+        }
+      ],
+      "payment": {
+        "prepaid": false,
+        "internal_copy": false,
+        "export_to_erp": false,
+        "payment_status": {
+          "value": "PAID"
+        },
+        "voucher_date": "2015-07-20",
+        "voucher_number": "A-1234",
+        "voucher_amount": "120",
+        "voucher_currency": {
+          "value": "USD"
+        }
+      },
+      "notes": [
+        {
+          "note_text": "Created by: John Smith"
+        }
+      ],
+      "invoice_lines": {
+        "total_record_count": 999,
+        "invoice_line": [
+          {
+            "link": "string",
+            "type": {
+              "value": "REGULAR"
+            },
+            "number": "10",
+            "po_line": "20",
+            "price": 50,
+            "price_note": "string",
+            "quantity": 10,
+            "vat_note": "string",
+            "check_subscription_date_overlap": false,
+            "fully_invoiced": false,
+            "subscription_from_date": "2015-07-20",
+            "subscription_to_date": "2015-07-20",
+            "additional_info": "string",
+            "release_remaining_encumbrance": false,
+            "reporting_code": {
+              "value": "b"
+            },
+            "secondary_reporting_code": {
+              "value": "sso"
+            },
+            "tertiary_reporting_code": {
+              "value": "u"
+            },
+            "note": "string",
+            "invoice_line_vat": {
+              "vat_code": {
+                "value": "string"
+              },
+              "percentage": 0,
+              "vat_amount": 0
+            },
+            "fund_distribution": [
+              {
+                "fund_code": {
+                  "value": "JKL"
                 },
                 "percent": 100,
                 "amount": -40.99

--- a/tests/fixtures/invoices.json
+++ b/tests/fixtures/invoices.json
@@ -587,6 +587,13 @@
                 },
                 "percent": 100,
                 "amount": -40.99
+              },
+              {
+                "fund_code": {
+                  "value": "over-encumbered"
+                },
+                "percent": 100,
+                "amount": -40.99
               }
             ]
           }

--- a/tests/fixtures/vendor_multibyte-address.json
+++ b/tests/fixtures/vendor_multibyte-address.json
@@ -1,0 +1,22 @@
+{
+  "code": "multibyte-address",
+  "name": "Vendor four",
+  "contact_info": {
+    "address": [
+      {
+        "preferred": true,
+        "line1": "PO Box 12‑34",
+        "city": "Tomorrowland",
+        "postal_code": "09876",
+        "country": {
+          "value": "USA"
+        },
+        "address_type": [
+          {
+            "value": "billing"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -75,7 +75,7 @@ def test_alma_get_vendor_details(mocked_alma, mocked_alma_api_client):
 
 def test_alma_get_vendor_invoices(mocked_alma, mocked_alma_api_client):
     invoices = mocked_alma_api_client.get_vendor_invoices("BKHS")
-    assert len(list(invoices)) == 3
+    assert len(list(invoices)) == 5
 
 
 def test_alma_get_po_line_full_record(mocked_alma, mocked_alma_api_client):


### PR DESCRIPTION
# Why these changes are being introduced:
In certain situations the Alma API may return no fund data as the result of a fund query.
This causes an error where the code was expecting to have fund data.

# How this addresses that need:
* adds error handling to functions that retrieve funds and parse invoices
* invoices with fund errors or multibyte characters are moved into a separate
object to handle them more easily
* adds warnings to summary about funds for which data was not retrieved
* updates tests

# Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ASI-46

#### What does this PR do?
Handles situations where the alma api returns zero funds in response to a fund query, 
specifically in cases where the fund has exceeded its overencumbrance limit.

#### How can a reviewer manually see the effects of these changes?

create sample invoice data in the sandbox. edit one of the funds such that the over-encumbrance
limit is below the encumbered amount for the fund.

perform a dry run in the sandbox

summary should include a message about the fund that is over-encumbred

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-

#### Includes new or updated dependencies?

NO

#### Changes expectations for external applications?

NO

#### Developer

- [ ] All new config values are documented in README
- [ ] All new config values have been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
