### PR TITLE
ENSY-98-acq-method-quantity

### DIFF
--- a/config/credit_card_slip_template.xml
+++ b/config/credit_card_slip_template.xml
@@ -44,11 +44,13 @@
       <tr>
         <td>PO Line #:</td>
         <td>TITLE:</td>
+        <td>QUANTITY</td>
         <td>PRICE</td>
       </tr>
       <tr>
         <td class="poline"></td>
         <td class="item_title"></td>
+        <td class="quantity"></td>
         <td class="price"></td>
       </tr>
       <tr>

--- a/llama/credit_card_slips.py
+++ b/llama/credit_card_slips.py
@@ -17,6 +17,8 @@ def create_po_line_dict(alma_api_client, po_line_record):
     total_price = get_total_price(po_line_record, price)
     po_line_dict["total_price"] = f"${total_price}"
 
+    po_line_dict["quantity"] = get_quantity_from_locations(po_line_record)
+
     po_line_created_date = get_po_line_created_date(po_line_record)
     po_line_dict["po_date"] = po_line_created_date
     po_line_dict[
@@ -75,8 +77,8 @@ def get_cardholder_from_notes(po_line_record):
 
 def get_credit_card_full_po_lines_from_date(alma_api_client, date):
     """Get a list of full PO line records for credit card purchases (acquisition_methood =
-    EXCHANGE) from the specified date."""
-    brief_po_lines = alma_api_client.get_brief_po_lines("EXCHANGE")
+    "PURCHASE_NOLETTER" from the specified date."""
+    brief_po_lines = alma_api_client.get_brief_po_lines("PURCHASE_NOLETTER")
     credit_card_full_po_lines = []
     for brief_po_line in (
         p
@@ -106,6 +108,20 @@ def get_po_title(po_line_record):
     title = po_line_record.get("resource_metadata", {}).get("title")
     title = "Unknown title" if title is None else title
     return title
+
+
+def get_quantity_from_locations(po_line_record):
+    """Get the total quantity of items associated with a PO line by adding up the
+    quantities from each location in the PO line. This is a imperfect method as
+    it may generate a total quantity than differs from what is visible in the
+    UI if some if the items are not associated with a location. Regardless, this is
+    the best available method given that the quantity listed in the UI is not
+    available in the API response. Stakeholders requested this with full knowledge
+    of the imperfections."""
+    quantity = 0
+    for location in po_line_record.get("location", [{}]):
+        quantity += location.get("quantity", 0)
+    return str(quantity)
 
 
 def get_total_price(po_line_record, unit_price):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,18 @@ def mocked_alma(po_line_record_all_fields):
                 ],
             },
         )
+        m.get(
+            (
+                "http://example.com/acq/po-lines?status=ACTIVE&"
+                "acquisition_method=PURCHASE_NOLETTER"
+            ),
+            json={
+                "total_record_count": 2,
+                "po_line": [
+                    {"number": "POL-789", "created_date": "2021-05-15Z"},
+                ],
+            },
+        )
         m.get("http://example.com/acq/po-lines/POL-123", json=po_line_record_all_fields)
         m.get("http://example.com/acq/po-lines/POL-456", json=po_line_record_wrong_date)
 
@@ -426,6 +438,7 @@ def po_line_record_all_fields():
             {"fund_code": {"value": "ABC"}, "amount": {"sum": "24.0"}}
         ],
         "note": [{"note_text": "CC-abc"}],
+        "location": [{"quantity": 1}, {"quantity": 1}],
     }
     return po_line_record_all
 

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -50,10 +50,15 @@ def test_alma_create_vendor(mocked_alma, mocked_alma_api_client):
     assert vendor["code"] == "BKHS"
 
 
-def test_alma_get_brief_po_lines(mocked_alma, mocked_alma_api_client):
+def test_alma_get_brief_po_lines_no_acq_method(mocked_alma, mocked_alma_api_client):
     po_line_stubs = mocked_alma_api_client.get_brief_po_lines()
     assert next(po_line_stubs) == {"created_date": "2021-05-13Z", "number": "POL-123"}
     assert next(po_line_stubs) == {"created_date": "2021-05-02Z", "number": "POL-456"}
+
+
+def test_alma_get_brief_po_lines_with_acq_method(mocked_alma, mocked_alma_api_client):
+    po_line_stubs = mocked_alma_api_client.get_brief_po_lines("PURCHASE_NOLETTER")
+    assert next(po_line_stubs) == {"created_date": "2021-05-15Z", "number": "POL-789"}
 
 
 def test_alma_get_fund_by_code(mocked_alma, mocked_alma_api_client):

--- a/tests/test_credit_card_slips.py
+++ b/tests/test_credit_card_slips.py
@@ -19,6 +19,7 @@ def test_create_po_line_dict_all_fields(
     assert po_line_dict["item_title"] == "Book title"
     assert po_line_dict["poline"] == "POL-123"
     assert po_line_dict["price"] == "$12.00"
+    assert po_line_dict["quantity"] == "2"
     assert po_line_dict["vendor"] == "Corporation"
 
 
@@ -39,6 +40,7 @@ def test_create_po_line_dict_missing_fields(
     assert po_line_dict_missing_fields["invoice_num"] == (
         "Invoice #: No PO Line created date foundUNK"
     )
+    assert po_line_dict_missing_fields["quantity"] == "0"
     assert po_line_dict_missing_fields["cardholder"] == "No cardholder note found"
 
 
@@ -81,6 +83,7 @@ def test_create_po_line_dicts(
         assert po_line_dict["item_title"] == "Book title"
         assert po_line_dict["poline"] == "POL-123"
         assert po_line_dict["price"] == "$12.00"
+        assert po_line_dict["quantity"] == "2"
         assert po_line_dict["vendor"] == "Corporation"
 
 
@@ -140,6 +143,16 @@ def test_get_po_title_with_title():
 def test_get_po_title_without_title():
     po_line_record = {"resource_metadata": {"title": None}}
     assert credit_card_slips.get_po_title(po_line_record) == "Unknown title"
+
+
+def test_get_quantity_from_locations_with_locations():
+    po_line_record = {"location": [{"quantity": 1}, {"quantity": 1}]}
+    assert credit_card_slips.get_quantity_from_locations(po_line_record) == "2"
+
+
+def test_get_quantity_from_locations_without_locations():
+    po_line_record = {}
+    assert credit_card_slips.get_quantity_from_locations(po_line_record) == "0"
 
 
 def test_get_total_price_with_total_price():


### PR DESCRIPTION
#### Helpful background context
There was an issue with the credit card slips automation not capturing the appropriate PO Lines at the beginning of the FY which was included in the [aggregator ticket](https://mitlibraries.atlassian.net/browse/ENSY-98). That issue seems to have resolved itself (without any clear reason) so nothing is included to address that.

#### How can a reviewer manually see the effects of these changes?
There is a difference in the API behavior on our sandbox instance vs. our prod instance that neither Tania or I have been able to find an explanation for. On prod, PO Lines are retrieved by looking for a `status` of `ACTIVE`, despite the returned record having a status of `SENT`. This is how the integration was initially set up and we've not had any issues except for the brief interruption at the start of this FY. On the sandbox however, searching for `ACTIVE` produces nothing, though the same PO Lines can be retrieved by looking for a status of `SENT`. For this reason, a fake PO Line was created in prod on 7-20 and it will be deleted after testing is complete. 

To verify this code:
- Set your local env `ALMA_API_ACQ_READ_KEY` to a production acquisitions read-only key
- Set prod/stage AWS credentials so that an email will be sent to you via SES
- Run the following command to verify that the test PO Line is retrieved and sent to your email

```
pipenv run llama cc-slips --source_email noreply@libraries.mit.edu --recipient_email <YOUR@EMAIL.ADDRESS> --date 2022-07-20 
```

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/ENSY-98
* https://mitlibraries.atlassian.net/browse/ES-768
* https://mitlibraries.atlassian.net/browse/INFRA-221

#### Includes new or updated dependencies?
NO

#### Changes expectations for external applications?
NO

#### Developer
- [X All new config values are documented in README
- [X] All new config values have been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)

#### Code Reviewer
- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
