### PR TITLE
map student_year value U to status 31

### DIFF
--- a/patronload/student.py
+++ b/patronload/student.py
@@ -317,7 +317,7 @@ for i in range(0, len(student)):
 
     for user_group in root.iter("user_group"):
         status = ""
-        if re.search("^[1234]$", patron["STUDENT_YEAR"]):
+        if re.search("^[1234Uu]$", patron["STUDENT_YEAR"]):
             status = "31"
         elif re.search("^[Gg]$", patron["STUDENT_YEAR"]):
             status = "32"


### PR DESCRIPTION
# Why these changes are being introduced:
patron year = 'U' is a possible value in records coming from datawarehouse, but is not covered by current code. According to the registrar’s office Patron year 'U' indicates “special student undergraduate i.e. non-degree students who are enrolled for the purpose of taking one or two courses."

According to IDLA, these students should be treated as normal undergraduates for the purpose of borrowing and should be assigned to the alma Undergraduate student user group '31'

# Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ENSY-114

#### What does this PR do?
* adds U to mapping for “Student - Undergraduate” ( patron group code = 31)

#### How can a reviewer manually see the effects of these changes?

- temporarily edit student.py such that it prints the MIT_ID for patrons with student_year == 'U' or 'u'
- run student.py
- find xml files in STUDENT folder for corresponding 'u' patrons
- for these patrons' xml files confirm that <user_group> == 31 

Delete this section if it isn't applicable to the PR.


#### Includes new or updated dependencies?

NO

#### Changes expectations for external applications?

NO

#### Developer

- [ ] All new config values are documented in README
- [ ] All new config values have been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
